### PR TITLE
lightning-item-iframe.js: fix content saving for new items

### DIFF
--- a/chrome/content/lightning-item-iframe.js
+++ b/chrome/content/lightning-item-iframe.js
@@ -161,7 +161,7 @@ exchangeEventDialog.prototype = {
 				this.newItem = item.bodyType.toLowerCase() !== "html";
 			}
 			else {
-				this._newItem = true;
+				this.newItem = true;
 				itemBodyEditor.content = item.getProperty("DESCRIPTION");
 			}
 


### PR DESCRIPTION
Fix little typo in item dialog javascript which bugged the save of content for newly created tasks.