### PR TITLE
Translate the addon to Italian

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -42,6 +42,7 @@ Some of the icons and images used are from the Fugue Icons Collection made by Yu
     <em:translator>Björn Töpper (de)</em:translator>
     <em:translator>Hiroshi Miura (ja-JP)</em:translator>
     <em:translator>Alexey Sinitsyn (ru)</em:translator>
+    <em:translator>Alessandro Menti (it-IT)</em:translator>
     <em:homepageURL>http://www.1st-setup.nl/wordpress/?page_id=133</em:homepageURL>
     <em:iconURL>chrome://exchangecalendar-common/skin/images/lightningexchangecalendar.png</em:iconURL>
     <em:type>2</em:type> <!-- type: extension -->
@@ -56,7 +57,7 @@ Some of the icons and images used are from the Fugue Icons Collection made by Yu
 You can view, delete, create and update calendar and task/todo items. And manage "Out of Office" settings.
 You can read and use contacts and global addres list contacts for address autcompletion.
 
-Dutch, French, English, German, Swedish and Japanese localizations.
+Dutch, French, English, German, Swedish, Japanese and Italian localizations.
 
 Some of the icons and images used are from the Fugue Icons Collection made by Yusuke Kamiyamane (http://p.yusukekamiyamane.com/)</em:description>
 		</Description>
@@ -123,5 +124,19 @@ Sommige van de iconen en plaatjes komen uit de Fugue Icons collectie gemaakt doo
 		</Description>
 	</em:localized>
 
+	<em:localized>
+		<Description>
+			<em:locale>it-IT</em:locale>
+			<em:name>Provider Exchange EWS</em:name>
+			<em:description>Consente di sincronizzare i propri Calendario, Attività e Contatti con un server Microsoft Exchange 2007/2010/2013 EWS da Lightning.
+
+È possibile visualizzare, eliminare, creare e aggiornare elementi del Calendario e Attività/Da fare e gestire le opzioni Fuori sede.
+È possibile leggere e utilizzare i propri contatti e i contatti della Global Address List per l'autocompletamento degli indirizzi.
+
+Localizzato in olandese, francese, inglese, tedesco, svedese, giapponese e italiano.
+
+Alcune delle icone e immagini utilizzate sono state tratte dalla Fugue Icons Collection di Yusuke Kamiyamane (http://p.yusukekamiyamane.com/)</em:description>
+		</Description>
+	</em:localized>
 	</Description>
 </RDF>

--- a/locale/exchangecalendar/it-IT/attachments-view.dtd
+++ b/locale/exchangecalendar/it-IT/attachments-view.dtd
@@ -1,0 +1,2 @@
+<!ENTITY exchWebServie.add.attachment.button.label "Allegati">
+

--- a/locale/exchangecalendar/it-IT/browseFolder.dtd
+++ b/locale/exchangecalendar/it-IT/browseFolder.dtd
@@ -1,0 +1,12 @@
+<!ENTITY label.acceptbutton "Seleziona">
+<!ENTITY label.cancelbutton "Annulla">
+
+<!ENTITY browsefolder.title "Sfoglia cartelle">
+
+<!ENTITY treecol.label.foldername "Nome cartella">
+<!ENTITY treecol.label.folderclass "Classe cartella">
+
+
+
+
+

--- a/locale/exchangecalendar/it-IT/calExchangeCalendar.properties
+++ b/locale/exchangecalendar/it-IT/calExchangeCalendar.properties
@@ -1,0 +1,49 @@
+displayName=Provider Calendario e Attività per Exchange 2007/2010
+
+resetEventMessage=Il calendario "%1$S" è stato reimpostato.
+addTaskEventMessage=Aggiunta attività "%1$S" (%2$S).
+addCalendarEventMessage=Aggiunto appuntamento "%1$S" (%2$S).
+ewsErrorEventMessage=Errore durante la comunicazione con il server EWS per "%1$S". Errore: %2$S, codice: %3$S.
+updateCalendarEventMessage=L'appuntamento "%1$S" è stato modificato (%2$S).
+updateTaskEventMessage=L'attività "%1$S" è stata modificata (%2$S).
+deleteCalendarEventMessage=L'appuntamento "%1$S" è stato rimosso (%2$S).
+deleteTaskEventMessage=L'attività "%1$S" è stata rimossa (%2$S).
+syncFolderEventMessage="%4$S": ricevuti aggiornamenti dal server EWS (nuovi: %1$S, modificati: %2$S, eliminati: %3$S).
+syncInboxRequests="%4$S": ricevuti aggiornamenti inviti a riunione dal server EWS nella Posta in arrivo (nuovi: %1$S, modificati: %2$S, eliminati: %3$S).
+syncInboxCancelations="%4$S": ricevuti annullamenti inviti a riunione dal server EWS nella Posta in arrivo (nuovi: %1$S, modificati: %2$S, eliminati: %3$S).
+syncInboxResponses="%4$S": ricevuti aggiornamenti risposte riunione dal server EWS nella Posta in arrivo (nuovi: %1$S, modificati: %2$S, eliminati: %3$S).
+ewsMeetingResponsEventMessage=Risposta "%2$S" ricevuta per la richiesta riunione "%1$S" (%3$S). Messaggio:
+
+ecErrorServerCheck=Errore durante il controllo sul server: %1$S (%2$S)
+ecErrorAutodiscovery=Errore durante la ricerca automatica: %1$S (%2$S)
+ecErrorAutodiscoveryURLInvalid=Non è stato possibile determinare le impostazioni tramite la ricerca automatica utilizzando la parte nome di dominio della casella di posta (%1$S).\nSolitamente ciò significa che non esiste un server ricerca automatica definito con la parte di dominio come nome host.
+ecErrorServerCheckURLInvalid=Il server "%1$S" non esiste.
+ecErrorServerAndMailboxCheck=Errore durante il controllo del server e della casella di posta: %1$S (codice: %2$S)
+
+updateUserPrefs1=Opzioni utente aggiornate per la nuova versione (dalla 0.7.26)
+
+autoRemoveConfirmedInvitationOnCancellation=L'appuntamento confermato "%1$S" è stato annullato ed è stato rimosso automaticamente come specificato dalle opzioni utente (%2$S).
+
+sendAutoRespondMeetingRequestMessage=È stata automaticamente inviata una risposta alla richiesta di riunione "%1$S" come specificato dalle opzioni utente (%2$S).
+
+ecLoadingOofSettings=(Recupero dati in corso)
+ecLoadedOofSettings=(Dati recuperati)
+ecErrorLoadingOofSettings=Errore durante il caricamento delle opzioni Fuori sede. Codice: %2$S, messaggio: %1$S.
+ecSavingOofSettings=(Salvataggio dati in corso)
+ecSavedOofSettings=(Dati salvati)
+ecErrorSavingOofSettings=Errore durante il salvataggio delle opzioni Fuori sede. Codice: %2$S, messaggio: %1$S.
+
+
+exchWebService.PidLidTaskHistory.duedate.changed=La data di scadenza è stata modificata
+exchWebService.PidLidTaskHistory.some.property.changed=È stata modificata una proprietà
+exchWebService.PidLidTaskHistory.accepted=Attività accettata da %1$S
+exchWebService.PidLidTaskHistory.rejected=Attività rifiutata da %1$S
+exchWebService.PidLidTaskHistory.assigned=Attività assegnata a %1$S
+exchWebService.PidLidTaskHistory.no.changes=Nessuna modifica
+
+ecErrorServerAndMailboxCheckFolderNotFound=Non si dispone delle autorizzazioni di lettura sulla casella di posta selezionata o la casella di posta non è corretta.\n\nDopo che la casella di posta sarà stata corretta si potrebbe disporre delle autorizzazioni di visualizzazione dello stato di disponibilità utente (occupato/provvisorio/fuori sede) per il suo calendario.\n\n(%2$S: %1$S)
+
+tooltipCalendarDisconnected=Il calendario %1$S non è connesso al server Exchange\n(Motivo: %2$S).
+tooltipCalendarDisconnectedReadOnly=Il calendario %1$S non è connesso al server Exchange ed è in sola lettura\n(Motivo: %2$S).
+tooltipCalendarConnected=Il calendario %1$S è connesso al server Exchange.
+tooltipCalendarConnectedReadOnly=Il calendario %1$S è connesso al server Exchange ed è in sola lettura.

--- a/locale/exchangecalendar/it-IT/calendar-calendars-list.dtd
+++ b/locale/exchangecalendar/it-IT/calendar-calendars-list.dtd
@@ -1,0 +1,5 @@
+<!ENTITY calendar.context.exchange.convert.label "Converti a componente aggiuntivo Calendario e Attività Exchange 2007/2010">
+<!ENTITY calendar.context.exchange.properties.label "Proprietà Exchange (EWS)">
+<!ENTITY calendar.context.exchange.oof.settings.label "Opzioni Fuori sede">
+<!ENTITY calendar.context.exchange.clone.settings.label "Clona opzioni in un nuovo calendario">
+<!ENTITY calendar.context.exchange.delegate.calendar.settings.label "Delega calendario">

--- a/locale/exchangecalendar/it-IT/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/it-IT/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Inoltra invito">
+<!ENTITY required.attendee.label "Partecipante richiesto">
+<!ENTITY optional.attendee.label "Partecipante facoltativo">

--- a/locale/exchangecalendar/it-IT/delegate-calendar-dialog.dtd
+++ b/locale/exchangecalendar/it-IT/delegate-calendar-dialog.dtd
@@ -1,0 +1,25 @@
+
+<!ENTITY  label.delegateCalendar.cancelbutton "Annulla">
+<!ENTITY  label.delegateCalendar.userEmail "Indirizzo di posta elettronica">
+<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl "Recapita richieste riunione">
+
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly "Solo ai delegati">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe "Ai delegati e a me">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo "Ai delegati e inviami le notifiche">
+
+<!ENTITY  label.delegateCalendar.permission "Autorizzazioni">
+<!ENTITY  menuitem.delegateCalendar.permission.author "Autore">
+<!ENTITY  menuitem.delegateCalendar.permission.editor "Editor">
+<!ENTITY  menuitem.delegateCalendar.permission.reviewer "Revisore">
+<!ENTITY  menuitem.delegateCalendar.permission.none "Nessuno">
+
+<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy "Ricevi copie dei messaggi riunione" >
+<!ENTITY  label.delegateCalendar.permission.viewPrivateItems "Visualizza elementi privati" >
+
+
+<!ENTITY  delegateCalendar.permission.description.author "Leggi e crea elementi nella cartella Calendario." >
+<!ENTITY  delegateCalendar.permission.description.editor "Leggi, crea e modifica elementi nella cartella Calendario." >
+<!ENTITY  delegateCalendar.permission.description.reviewer "Leggi elementi nella cartella Calendario." >
+<!ENTITY  delegateCalendar.permission.description.none "Nessuna autorizzazione di accesso alla cartella Calendario." >
+
+<!ENTITY  delegateCalendar.permission.details.label "Dettagli autorizzazioni: " >

--- a/locale/exchangecalendar/it-IT/delegate-folder.dtd
+++ b/locale/exchangecalendar/it-IT/delegate-folder.dtd
@@ -1,0 +1,45 @@
+
+<!ENTITY  label.delegatefolder.cancelbutton "Annulla">
+<!ENTITY  label.delegatefolder.userEmail "Indirizzo di posta elettronica">
+
+<!ENTITY  label.delegatefolder.permissionLevel "Livello autorizzazioni">
+<!ENTITY  label.delegatefolder.userboxcolumn1 "Utente">
+<!ENTITY  label.delegatefolder.userboxcolumn2 "Permessi">
+
+<!ENTITY  menuitem.delegatefolder.permission.author "Autore">
+<!ENTITY  menuitem.delegatefolder.permission.editor "Editor">
+<!ENTITY  menuitem.delegatefolder.permission.reviewer "Revisore">
+<!ENTITY  menuitem.delegatefolder.permission.none "Nessuno">
+<!ENTITY  menuitem.delegatefolder.permission.owner "Proprietario" >
+<!ENTITY  menuitem.delegatefolder.permission.publishingEditor "Supervisore pubblicazione" >
+<!ENTITY  menuitem.delegatefolder.permission.publishingAuthor "Autore pubblicazione" >
+<!ENTITY  menuitem.delegatefolder.permission.noneditingAuthor "Autore nonediting" >
+<!ENTITY  menuitem.delegatefolder.permission.contributor "Collaboratore" >
+<!ENTITY  menuitem.delegatefolder.permission.custom "Personalizzato" >
+
+<!ENTITY  delegatefolder.permission.description.author "Leggi e crea elementi nella cartella." >
+<!ENTITY  delegatefolder.permission.description.editor "Leggi, crea e modifica elementi nella cartella." >
+<!ENTITY  delegatefolder.permission.description.reviewer "Leggi elementi nella cartella." >
+<!ENTITY  delegatefolder.permission.description.none "Nessuna autorizzazione di accesso alla cartella." >
+
+<!ENTITY  delegatefolder.permission.details.caption "Autorizzazioni ">
+
+<!ENTITY  delegatefolder.tab.msg.label  "Calendario e Attività non trovati per questo account di posta.">
+<!ENTITY  delegatefolder.tab.name  "Condivisione cartelle Exchange">
+
+<!ENTITY  delegatefolder.permissions.none  "Nessuno">
+<!ENTITY  delegatefolder.permissions.own  "Propri elementi">
+<!ENTITY  delegatefolder.permissions.all  "Tutti gli elementi">
+<!ENTITY  delegatefolder.permissions.full  "Dettagli completi">
+
+<!ENTITY  delegatefolder.permissions.cancreateitems  "Creazione elementi">
+<!ENTITY  delegatefolder.permissions.cancreatesubfolders  "Creazione sottocartelle">
+<!ENTITY  delegatefolder.permissions.isfolderowner  "Proprietario cartella">
+<!ENTITY  delegatefolder.permissions.isfoldervisible  "Cartella visibile">
+<!ENTITY  delegatefolder.permissions.isfoldercontact  "Cartella contatti">
+<!ENTITY  delegatefolder.permissions.edititems  "Modifica elementi">
+<!ENTITY  delegatefolder.permissions.deleteitems  "Eliminazione elementi">
+<!ENTITY  delegatefolder.permissions.readitems  "Lettura elementi">
+
+<!ENTITY  delegatefolder.permissions.true  "Vero">
+<!ENTITY  delegatefolder.permissions.false  "Falso">

--- a/locale/exchangecalendar/it-IT/ecCalendarCreation.dtd
+++ b/locale/exchangecalendar/it-IT/ecCalendarCreation.dtd
@@ -1,0 +1,5 @@
+<!ENTITY exchange1.description "Opzioni Exchange/Windows Active Directory">
+<!ENTITY exchange.cache.label "Utilizza cache offline">
+
+
+

--- a/locale/exchangecalendar/it-IT/exchangeCloneSettings.dtd
+++ b/locale/exchangecalendar/it-IT/exchangeCloneSettings.dtd
@@ -1,0 +1,6 @@
+<!ENTITY label.acceptbutton "Salva">
+<!ENTITY label.cancelbutton "Annulla">
+
+<!ENTITY label.ecExchangeSettings.title "Nuova descrizione:">
+
+

--- a/locale/exchangecalendar/it-IT/exchangeReminderDialog.dtd
+++ b/locale/exchangecalendar/it-IT/exchangeReminderDialog.dtd
@@ -1,0 +1,4 @@
+<!ENTITY exchWebService.reminder.relation.origin.label "prima dell'inizio dell'evento">
+
+
+

--- a/locale/exchangecalendar/it-IT/exchangeSettings.dtd
+++ b/locale/exchangecalendar/it-IT/exchangeSettings.dtd
@@ -1,0 +1,54 @@
+<!ENTITY label.acceptbutton "Salva e reimposta">
+<!ENTITY label.cancelbutton "Annulla">
+<!ENTITY ecsettings.title "Opzioni Calendario e Posta EWS">
+<!ENTITY ecsettings.tab.adsettings "Exchange/AD Windows">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Richieste riunione">
+<!ENTITY ecsettings.tab.calendarfolderproperties "Proprietà cartella">
+
+<!ENTITY label.ecExchangeSettings.title "Opzioni per il calendario:">
+
+<!ENTITY label.poll.inbox "Esegui il polling della Posta in arrivo per gestire richieste, modifiche e annullamenti.">
+<!ENTITY label.poll.inbox.interval "Frequenza di polling Posta in arrivo (in secondi):">
+<!ENTITY label.poll.calendar.interval "Frequenza di polling Calendario (in secondi):">
+
+<!ENTITY label.nomeetingrequestsettings "Impossibile impostare la richiesta riunione perché non si è selezionato il calendario principale per la casella di posta">
+
+<!ENTITY label.autorespond.meetingrequest "Rispondi automaticamente a un nuovo invito con ">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "Forse parteciperò">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "Parteciperò">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "Non parteciperò">
+
+<!ENTITY label.autoremove.invitation_cancellation1 "Rimuovi automaticamente l'invito e il messaggio di annullamento abbinato se non si è ancora risposto all'invito.">
+<!ENTITY label.autoremove.invitation_cancellation2 "Rimuovi automaticamente un invito confermato quando si riceve un messaggio di annullamento.">
+
+<!ENTITY label.autoremove.invitation_response1 "Rimuovi automaticamente una risposta di terzi a un invito di cui non si è l'organizzatore.">
+
+<!ENTITY label.doautorespond.meetingrequest.message "Invia il seguente messaggio con le risposte anziché richiedere un messaggio.">
+<!ENTITY label.autorespond.meetingrequest.message "Messaggio:">
+
+<!ENTITY treecol.label.userid "Nome utente">
+<!ENTITY treecol.label.email "Indirizzo di posta elettronica">
+
+
+<!ENTITY ecsettings.tab.offlineCachingproperties "Cache non in linea">
+
+<!ENTITY label.offlineCacheproperties.cachingStartDate "Data di inizio cache:">
+<!ENTITY label.offlineCacheproperties.cachingEndDate "Data di fine cache:">
+<!ENTITY label.offlineCacheproperties.totalEvents "Numero totale di eventi in cache:">
+<!ENTITY label.offlineCacheproperties.totalTasks "Numero totale di attività in cache:">
+
+<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate "Numero di mesi prima di oggi per cui mantenere gli elementi in cache:">
+<!ENTITY label.offlineCacheproperties.monthsBeforeEndDate "Numero di mesi dopo di oggi per cui mantenere gli elementi in cache:">
+
+<!ENTITY button.offlineCacheproperties.clearCache "Elimina dati nella cache non in linea">
+<!ENTITY ecsettings.tab.autoprocessingproperties "Elaborazione automatica">
+<!ENTITY ecsettings.tab.mailitemsProperties "Opzioni EWS (Posta)">
+
+<!ENTITY label.syncmailitems.interval "Ritarda sincronizzazione elementi di posta (tag, ecc.)">
+<!ENTITY label.autoprocessingproperties.deletecancelleditems "Rimuovi automaticamente eventi annullati">
+<!ENTITY label.autoprocessingproperties.markeventtentative "Contrassegna automaticamente gli eventi come provvisori e invia la risposta all'organizzatore">
+<!ENTITY label.syncmailitems.active "Mantieni attiva la sincronizzazione degli elementi di posta (tag, ecc.)">
+
+<!ENTITY label.syncfollowup.deactivtate "Disabilita Contrassegna attività per il completamento">
+

--- a/locale/exchangecalendar/it-IT/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/it-IT/exchangeSettingsOverlay.dtd
@@ -1,0 +1,56 @@
+<!ENTITY ecautodiscover "Utilizza funzionalità ricerca automatica di Exchange.">
+<!ENTITY ecfolderbase.label "Cartella base:">
+<!ENTITY ecfolderpath.label "Percorso entro la cartella base:">
+<!ENTITY ecfolderidofshare.label "ID cartella condivisa:">
+<!ENTITY exchWebServices.SharedFolderID.label "Nome visualizzato cartella condivisa:">
+
+<!ENTITY menuitem.label.ecfolderbase.calendar "Cartella Calendario">
+<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot "Cartelle pubbliche">
+<!ENTITY menuitem.label.ecfolderbase.inbox "Cartella Posta in arrivo">
+<!ENTITY menuitem.label.ecfolderbase.voicemail "Cartella Segreteria telefonica">
+<!ENTITY menuitem.label.ecfolderbase.msgfolderroot "Radice cartella messaggi">
+<!ENTITY menuitem.label.ecfolderbase.root "Radice casella di posta">
+<!ENTITY menuitem.label.ecfolderbase.tasks "Cartella Attività">
+
+<!ENTITY menuitem.label.ecfolderbase.contacts "Cartella Contatti">
+<!ENTITY menuitem.label.ecfolderbase.deleteditems "Cartella Elementi eliminati">
+<!ENTITY menuitem.label.ecfolderbase.drafts "Cartella Bozze">
+<!ENTITY menuitem.label.ecfolderbase.journal "Cartella Diario">
+<!ENTITY menuitem.label.ecfolderbase.notes "Cartella Note">
+<!ENTITY menuitem.label.ecfolderbase.outbox "Cartella Posta in uscita">
+<!ENTITY menuitem.label.ecfolderbase.sentitems "Cartella Posta inviata">
+<!ENTITY menuitem.label.ecfolderbase.junkemail "Cartella Posta indesiderata">
+<!ENTITY menuitem.label.ecfolderbase.searchfolders "Cartella Ricerca cartelle">
+<!ENTITY menuitem.label.ecfolderbase.version2010 "-- Le opzioni sottostanti sono valide solo per Exchange 2010 --">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot "Cartella radice Elementi ripristinabili">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions "Cartella Eliminazioni in Elementi ripristinabili">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion "Cartella Versioni in Elementi ripristinabili">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges "Cartella Elimina in Elementi ripristinabili">
+<!ENTITY menuitem.label.ecfolderbase.archiveroot "Cartella radice Archivio">
+<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot "Cartella radice messaggi Archivio">
+<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems "Cartella Elementi eliminati Archivio">
+<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot "Cartella radice Elementi ripristinabili - Archivio">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsdeletions "Cartella Eliminazioni in Elementi ripristinabili - Archivio">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsversions "Cartella Versioni in Elementi ripristinabili - Archivio">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemspurges "Cartella Elimina in Elementi ripristinabili - Archivio">
+
+<!ENTITY button.label.autodiscovercheck "Esegui ricerca automatica">
+<!ENTITY button.label.serverandmailboxcheck "Controlla server e casella di posta">
+<!ENTITY button.label.servercheck "Controlla server e account">
+
+<!ENTITY ecmailbox.label "Indirizzo di posta elettronica principale:">
+<!ENTITY ecmailbox.tooltip "Non specificando una casella di posta si sarà in grado di accedere solamente alle cartelle pubbliche.">
+<!ENTITY ecwindowsuser.label "Nome utente:">
+<!ENTITY ecwindowsdomain.label "Nome dominio:">
+<!ENTITY ecwindowspassword.label "Password:">
+
+<!ENTITY button.label.folderpathcheck "Controlla">
+<!ENTITY button.label.folderbrowse "Sfoglia">
+
+<!ENTITY exchWebServices.UserAvailability.label "Per il calendario della casella di posta sarà visibile unicamente lo stato di disponibilità utente.">
+
+<!ENTITY exchWebServices.exchtype.label "Tipo Exchange">
+<!ENTITY exchWebServices.hostexch.label "Exchange hosted">
+<!ENTITY exchWebServices.365exch.label "Microsoft Office 365">
+<!ENTITY exchWebServices.detail.label "Dettagli">
+

--- a/locale/exchangecalendar/it-IT/extra-priority.dtd
+++ b/locale/exchangecalendar/it-IT/extra-priority.dtd
@@ -1,0 +1,18 @@
+<!ENTITY prefwindow.title "Opzioni aggiuntive">
+<!ENTITY general.label  "Generale">
+<!ENTITY about.label "Informazioni su">
+
+<!ENTITY about.description.label "Funzionalità avanzate per Thunderbird e SeaMonkey">
+<!ENTITY iconify.label "Visualizza solo icone priorità">
+<!ENTITY shadeHigh.label "Aggiungi un colore di sfondo ai messaggi con priorità alta">
+<!ENTITY shadeLow.label "Aggiungi un colore di sfondo ai messaggi con priorità bassa">
+<!ENTITY tagImportant.label "Contrassegna automaticamente i messaggi con priorità alta come Importante">
+
+<!ENTITY highestColor.label "Massima">
+
+<!ENTITY highColor.label "Alta">
+<!ENTITY lowColor.label "Bassa">
+<!ENTITY lowestColor.label "Minima">
+
+<!ENTITY prioritycolor  "Colore personalizzato">
+<!ENTITY pref.color "Opzioni colore:">

--- a/locale/exchangecalendar/it-IT/invitationResponse.dtd
+++ b/locale/exchangecalendar/it-IT/invitationResponse.dtd
@@ -1,0 +1,20 @@
+<!ENTITY label.acceptbutton "Conferma modifica">
+<!ENTITY label.cancelbutton "Annulla modifica">
+
+<!ENTITY description.invitationResponse "Conferma la modifica della risposta per la riunione.">
+
+<!ENTITY label.calendarName "Calendario:">
+<!ENTITY label.itemTitle "Oggetto:">
+<!ENTITY label.itemStart "Ora di inizio:">
+<!ENTITY label.itemResponse "Risposta:">
+<!ENTITY label.meetingOrganiser "Organizzatore:">
+
+<!ENTITY label.messageReponseBody "Messaggio risposta:">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "Forse parteciperò">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "Parteciperò">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "Non parteciperò">
+
+<!ENTITY label.proposenewtime.title "Proponi nuovo orario (Exchange 2013 o successivo)">
+<!ENTITY label.proposenewtime.start "Ora di inizio">
+<!ENTITY label.proposenewtime.end "Ora di fine">

--- a/locale/exchangecalendar/it-IT/inviteStyle.dtd
+++ b/locale/exchangecalendar/it-IT/inviteStyle.dtd
@@ -1,0 +1,2 @@
+<!ENTITY label.inviteCol "Invito a calendario">
+<!ENTITY tooltip.inviteCol "Ordina per invito">

--- a/locale/exchangecalendar/it-IT/lightning-item-iframe.dtd
+++ b/locale/exchangecalendar/it-IT/lightning-item-iframe.dtd
@@ -1,0 +1,7 @@
+<!ENTITY exchWebService.owner.label "Proprietario:">
+<!ENTITY exchWebService.totalWork.label "Lavoro totale:">
+<!ENTITY exchWebService.actualWork.label "Lavoro effettivo:">
+<!ENTITY exchWebService.mileage.label "Chilometraggio:">
+<!ENTITY exchWebService.billingInformation.label "Informazioni di fatturazione:">
+<!ENTITY exchWebService.companies.label "Azienda:">
+

--- a/locale/exchangecalendar/it-IT/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/it-IT/manageEWSAccounts.dtd
@@ -1,0 +1,16 @@
+<!ENTITY label.acceptbutton "Chiudi">
+
+<!ENTITY exchWebService.manageEWSAccounts.newAccount.button "Aggiungi account">
+<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button "Rimuovi account">
+<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Salva impostazioni">
+
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Utilizza la funzionalità di ricerca automatica di Exchange.">
+<!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Nome casella di posta:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Nome utente:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Nome dominio:">
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button "Esegui ricerca automatica">
+<!ENTITY exchWebService.manageEWSAccounts.servercheck.button "Controlla server e account">
+<!ENTITY exchWebService.manageEWSAccounts.name.label "Nome:">
+
+<!ENTITY exchWebService.manageEWSAccounts.menuitem "Account Exchange Web Services">
+

--- a/locale/exchangecalendar/it-IT/messenger_task_delegation.dtd
+++ b/locale/exchangecalendar/it-IT/messenger_task_delegation.dtd
@@ -1,0 +1,6 @@
+<!ENTITY exchWebService.task.delegation.owner.name "Proprietario attività">
+<!ENTITY exchWebService.task.delegation.delegator.name "Delegato attività">
+<!ENTITY exchWebService.task.delegation.accept.button "Accetta">
+<!ENTITY exchWebService.task.delegation.decline.button "Rifiuta">
+<!ENTITY exchWebService.task.delegation.lastUpdateDate "Ultima modifica">
+

--- a/locale/exchangecalendar/it-IT/oofSettings.dtd
+++ b/locale/exchangecalendar/it-IT/oofSettings.dtd
@@ -1,0 +1,26 @@
+<!ENTITY title.oofsettings "Opzioni Fuori sede">
+<!ENTITY label.acceptbutton "Salva">
+<!ENTITY label.cancelbutton "Chiudi">
+<!ENTITY label.oofsettings.title "Opzioni Fuori sede per:">
+
+<!ENTITY label.oofstatus "Stato Fuori sede:">
+
+<!ENTITY label.externalaudience "Persone esterne a cui inviare messaggi Fuori sede: ">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none "Nessuno">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known "Solo persone nel mio elenco contatti">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all "Tutti">
+
+<!ENTITY button.label.internal "Messaggio interno">
+<!ENTITY button.label.external "Messaggio esterno">
+<!ENTITY label.internalreply "Messaggio che sarà inviato alle persone nella propria impresa:">
+<!ENTITY label.externalreply "Messaggio che sarà inviato alle persone al di fuori della propria impresa:">
+
+<!ENTITY menuitem.label.exchWebService-oof-status.disabled "Disabilitato">
+<!ENTITY menuitem.label.exchWebService-oof-status.enabled "Abilitato">
+
+<!ENTITY checkbox.label.exchWebService-oof-scheduled "Abilitato solo nell'intervallo temporale specificato:">
+<!ENTITY label.hbox-oof-scheduled-startTime "Ora di inizio:">
+<!ENTITY label.hbox-oof-scheduled-endTime "Ora di fine:">
+
+
+

--- a/locale/exchangecalendar/it-IT/preInvitationResponse.dtd
+++ b/locale/exchangecalendar/it-IT/preInvitationResponse.dtd
@@ -1,0 +1,14 @@
+<!ENTITY dialog.exchWebService.preInvitationResponse.title "Come si desidera rispondere?">
+<!ENTITY label.acceptbutton "OK">
+<!ENTITY label.cancelbutton "Annulla">
+
+<!ENTITY label.calendarName "Calendario:">
+<!ENTITY label.itemTitle "Oggetto:">
+<!ENTITY label.itemStart "Ora di inizio:">
+<!ENTITY label.itemResponse "Risposta:">
+<!ENTITY label.meetingOrganiser "Organizzatore:">
+
+<!ENTITY radio.label.exchWebService.preInvitationResponse.edit "Modifica la risposta prima di inviarla.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow "Invia la risposta ora.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend "Non inviare una risposta.">
+

--- a/locale/exchangecalendar/it-IT/preferences.dtd
+++ b/locale/exchangecalendar/it-IT/preferences.dtd
@@ -1,0 +1,48 @@
+<!ENTITY exchangeWebService.paneAccounts.title "Exchange (EWS)">
+<!ENTITY exchangeWebService.paneDebug.title "Registrazione eventi">
+
+<!ENTITY exchangeWebService.preferences.tab.accounts "Account">
+<!ENTITY exchangeWebService.preferences.tab.debug "Registrazione eventi">
+<!ENTITY exchangeWebService.preference.debug.file "Percorso file di log:">
+<!ENTITY exchangeWebService.preference.network.debug.caption "Comunicazioni con il server Exchange:">
+<!ENTITY exchangeWebService.preference.debug.log.label "Registra informazioni sulla console e/o su un file">
+<!ENTITY exchangeWebService.preference.debug.file.button "Sfoglia">
+<!ENTITY exchangeWebService.preference.network.debug.label "Registra comunicazioni con il server Exchange">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label1 "Livello di log">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label2 "1 = informazioni di base, 2 = comunicazioni integrali">
+<!ENTITY exchangeWebService.preference.authentication.debug.label "Registra informazioni sull'avanzamento delle comunicazioni (ad es. autenticazione)">
+<!ENTITY exchangeWebService.preference.authentication.showpassword.label "Visualizza la password come testo in chiaro nel file di log.">
+
+<!ENTITY exchangeWebService.preference.contacts.debug.caption "Rubrica/Contatti:">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label1 "Livello di log">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label2 "1 = informazioni di base, 2 = comunicazioni integrali">
+<!ENTITY exchangeWebService.preference.contacts.debug.label "Registra informazioni relative alla Rubrica/Contatti">
+
+<!ENTITY exchangeWebService.preferences.titleWin "Opzioni Exchange (EWS)">
+
+<!ENTITY exchangeWebService.preference.core.debug.caption "Oggetto core provider:">
+<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = nessuna informazione, 1 = informazioni di base, 2 = comunicazioni integrali">
+
+<!ENTITY exchangeWebService.preferences.tab.cache "Caching">
+<!ENTITY exchangeWebService.preference.cache.memory.label "Cache minimale temporanea in memoria">
+<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label "Numero di giorni di cui scaricare i dati prima della data di avvio del programma:">
+<!ENTITY exchangeWebService.preference.cache.memory.startupAfter.label "Numero di giorni di cui scaricare i dati dopo la data di avvio del programma:">
+
+<!ENTITY exchangeWebService.preferences.tab.others "Altro">
+<!ENTITY exchangeWebService.preference.others.prefs.label "Opzioni comunicazioni:">
+<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label "Numero massimo di tentativi per le comunicazioni con Exchange:">
+
+<!ENTITY exchangeWebService.preference.updateFunction.label "Funzionalità aggiornamento componente aggiuntivo:">
+<!ENTITY exchangeWebService.preference.checkForUpdates.label "Controlla automaticamente la disponibilità di una nuova versione del componente aggiuntivo su Internet all'avvio di Thunderbird.">
+<!ENTITY exchangeWebService.preference.warnForUpdates.label "Visualizza un avviso se una nuova versione è disponibile per consentirne un'installazione facile.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Visualizza un avviso se una nuova versione non definitiva (beta, RC, ecc.) è disponibile.">
+
+<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Bilanciamento del carico:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Bilanciamento del carico:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Numero massimo di richieste contemporanee al server Exchange:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Tempo minimo di attesa fra richieste al server Exchange:">
+<!ENTITY exchangeWebService.preference.userAgent.label "Agente utente HTTP:">
+
+<!ENTITY exchangeWebService.preference.ntlmv1.label "Opzioni NTLM-v1:">
+<!ENTITY exchangeWebService.preference.ntlmv1.true.label "Abilita">
+<!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disabilita">

--- a/locale/exchangecalendar/it-IT/rtews.dtd
+++ b/locale/exchangecalendar/it-IT/rtews.dtd
@@ -1,0 +1,15 @@
+ <!ENTITY rtews.selectaccountdesc "Selezionare l'account di posta elettronica da configurare. L'account deve essere basato su Microsoft Exchange">
+ <!ENTITY rtews.accconfigured "Account già configurato">
+ <!ENTITY rtews.dicoverdesc "È possibile scegliere di ricercare automaticamente l'URL del server Microsoft Exchange (EWS) URL o configurarlo manualmente">
+ <!ENTITY rtews.dicoverdesc2 "Per configurarlo manualmente, immettere l'URL nel campo sottostante.">
+ <!ENTITY rtews.autodiscover "Ricerca automatica">
+ <!ENTITY rtews.doautodicover "Esegui ricerca automatica">
+ <!ENTITY rtews.manual "Manuale">
+ <!ENTITY rtews.test "Fare clic qui per verificare l'URL EWS">
+ <!ENTITY rtews.msexchewsurl "URL EWS Microsoft Exchange EWS verificato. Cliccare Fine per completare la configurazione">
+ <!ENTITY rtews.selectaccount "Seleziona account">
+ <!ENTITY rtews.configure.label "Configura...">
+ <!ENTITY rtews.rtforexch "Contrassegni remoti per Microsoft Exchange">
+ <!ENTITY rtews.confirmAccDetail "Confermare i seguenti dettagli dell'account">
+ <!ENTITY rtews.username "Nome utente">
+ <!ENTITY rtews.domain "Dominio">

--- a/locale/exchangecalendar/it-IT/rtews.properties
+++ b/locale/exchangecalendar/it-IT/rtews.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=Si è verificato un errore durante la creazione del tag per la categoria

--- a/locale/exchangecalendar/it-IT/selectEWSUrl.dtd
+++ b/locale/exchangecalendar/it-IT/selectEWSUrl.dtd
@@ -1,0 +1,9 @@
+<!ENTITY label.acceptbutton "Seleziona">
+<!ENTITY label.cancelbutton "Annulla">
+
+<!ENTITY description.selectews "Selezionare dall'elenco un server EWS adatto alla posizione corrente.">
+<!ENTITY label.selectews "Elenco server EWS:">
+
+
+
+

--- a/locale/exchangecalendar/it-IT/sendUpdateTo.dtd
+++ b/locale/exchangecalendar/it-IT/sendUpdateTo.dtd
@@ -1,0 +1,9 @@
+<!ENTITY title.sendupdateto "A chi dev'essere inviato quest'aggiornamento?">
+<!ENTITY label.acceptbutton "Esegui">
+<!ENTITY label.cancelbutton "Annulla">
+<!ENTITY label.calendaritem.title "Invia aggiornamento per la riunione:">
+
+<!ENTITY radio.label.sendtonone "Non inviare l'aggiornamento a nessuno.">
+<!ENTITY radio.label.sendtoall "Invia l'aggiornamento a tutti gli invitati.">
+<!ENTITY radio.label.sendtochanged "Invia l'aggiornamento solo alle persone aggiunte o rimosse.">
+

--- a/locale/exchangecalendar/it-IT/sharedCalendarParser.dtd
+++ b/locale/exchangecalendar/it-IT/sharedCalendarParser.dtd
@@ -1,0 +1,3 @@
+<!ENTITY exchWebService_vbox_label "Rilevato invito condivisione Exchange">
+<!ENTITY exchWebService_button_label_add_calendar "Aggiungi calendario">
+

--- a/locale/exchangecalendar/it-IT/timezonePreference.dtd
+++ b/locale/exchangecalendar/it-IT/timezonePreference.dtd
@@ -1,0 +1,1 @@
+<!ENTITY calendar.timezone.local.auto.label  "Modifica fuso orario automaticamente">


### PR DESCRIPTION
This pull request adds the Italian localization to the addon.

Note: the text `Dutch, French, English, German, Swedish, Japanese and Italian localizations.` in `install.rdf` needs to be updated in the Dutch/French/German/Swedish/Japanese addon descriptions in the same file.