### PR TITLE
Fix HTML content editor

### DIFF
--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -195,8 +195,13 @@
     </content>
 	<implementation>
 		<constructor><![CDATA[
-			this.editorElement = document.getAnonymousElementByAttribute(this, "anonid", "editor");
 			var self=this;
+
+			// To be able to set correct HTML content
+			this.globalFunctions = Components.classes["@1st-setup.nl/global/functions;1"]
+				.getService(Components.interfaces.mivFunctions);
+
+			this.editorElement = document.getAnonymousElementByAttribute(this, "anonid", "editor");
 			if (this.editorElement) {
 				this.commandManager = this.editorElement.commandManager;
 				this.editorClickFunction = function(aEvent) { self.onClickEditor(aEvent);};
@@ -214,15 +219,12 @@
 				this.editorElement.addEventListener("mouseover", this.editorMouseOver , false);
 				this.editorElement.addEventListener("mouseout", this.editorMouseOut, false);
 
+				// Set default document to empty HTML content
+				this.editorElement.contentDocument.documentElement.innerHTML = this.globalFunctions.fromText2HTML(null);
 			}
 
 			this.atomService = Components.classes["@mozilla.org/atom-service;1"]
 				.getService(Components.interfaces.nsIAtomService);
-
-			// Set initial content to empty HTML body
-			this.globalFunctions = Components.classes["@1st-setup.nl/global/functions;1"]
-				.getService(Components.interfaces.mivFunctions);
-			this.editorElement.contentDocument.documentElement.innerHTML = this.globalFunctions.fromText2HTML(null);
 
 			this.connectButtons("FormatToolbar");
 			// Connect color button

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -210,13 +210,13 @@
 			if (this.editorElement) {
 				this.commandManager = this.editorElement.commandManager;
 				this.editorClickFunction = function(aEvent) { self.onClickEditor(aEvent);};
-				this.editorElement.addEventListener("click", this.editorClickFunction, true);
+				this.editorElement.addEventListener("click", this.editorClickFunction, false);
 
 				this.editorDblClickFunction = function(aEvent) { self.onDblClickEditor(aEvent);};
-				this.editorElement.addEventListener("dblclick", this.editorDblClickFunction, true);
+				this.editorElement.addEventListener("dblclick", this.editorDblClickFunction, false);
 
 				this.editorKeyPressFunction = function(aEvent) { self.onKeyPressEditor(aEvent);};
-				this.editorElement.addEventListener("keyup", this.editorKeyPressFunction, true);
+				this.editorElement.addEventListener("keyup", this.editorKeyPressFunction, false);
 
 				this.editorMouseOver = function(aEvent) { self.onMouseOver(aEvent);};
 				this.editorElement.addEventListener("mouseover", this.editorMouseOver , false);
@@ -236,11 +236,11 @@
 			// Connect color button
 			this.bgColorFunction = function(){ self.selectColor("cmd_backgroundColor");};
 			var bgColorElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_backgroundColor")
-			bgColorElement.addEventListener("click", this.bgColorFunction, true);
+			bgColorElement.addEventListener("click", this.bgColorFunction, false);
 
 			this.fontColorFunction = function(){ self.selectColor("cmd_fontColor");};
 			var fontColorElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_fontColor")
-			fontColorElement.addEventListener("click", this.fontColorFunction, true);
+			fontColorElement.addEventListener("click", this.fontColorFunction, false);
 
 			this.highlightColor = "#FFFFFF";
 			this.fontColor = "#000000";
@@ -248,21 +248,21 @@
 			// Connect FontFace popup menu
 			this.menuPopupFunction = function(event){ self.selectFont("cmd_fontFace", event.target.value);};
 			this.menuPopup = document.getAnonymousElementByAttribute(this, "anonid", "fontFaceSelect");
-			this.menuPopup.addEventListener("command", this.menuPopupFunction, true);
+			this.menuPopup.addEventListener("command", this.menuPopupFunction, false);
 			this.fillFontFace();
 
 			// Connect HyperLink buttons
 			this.addLinkFunction = function(){ self.addLink();};
 			var addLinkElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_add_link")
-			addLinkElement.addEventListener("click", this.addLinkFunction, true);
+			addLinkElement.addEventListener("click", this.addLinkFunction, false);
 
 			this.removeLinkFunction = function(){ self.removeLink();};
 			var removeLinkElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_remove_link")
-			removeLinkElement.addEventListener("click", this.removeLinkFunction, true);
+			removeLinkElement.addEventListener("click", this.removeLinkFunction, false);
 
 			this.editLinkFunction = function(){ self.editLink();};
 			var editLinkElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_edit_link")
-			editLinkElement.addEventListener("click", this.editLinkFunction, true);
+			editLinkElement.addEventListener("click", this.editLinkFunction, false);
 		]]></constructor>
 
 		<destructor><![CDATA[
@@ -270,7 +270,7 @@
 				this.editorElement.removeEventListener("click", this.editorClickFunction, false);
 				this.editorElement.removeEventListener("keyup", this.editorKeyPressFunction, false);
 
-				this.editorElement.removeEventListener("dblclick", this.editorDblClickFunction, true);
+				this.editorElement.removeEventListener("dblclick", this.editorDblClickFunction, false);
 
 				this.editorElement.removeEventListener("mouseover", this.editorMouseOver , false);
 				this.editorElement.removeEventListener("mouseout", this.editorMouseOut, false);
@@ -279,8 +279,10 @@
 			this.removeAllCommandListenerToolbar("FormatToolbar");
 
 			// Disconnect color button
-			document.getAnonymousElementByAttribute(this, "anonid", "cmd_backgroundColor").removeEventListener("click", this.bgColorFunction, false);
-			document.getAnonymousElementByAttribute(this, "anonid", "cmd_fontColor").removeEventListener("click", this.fontColorFunction, false);
+			document.getAnonymousElementByAttribute(this, "anonid", "cmd_backgroundColor")
+				.removeEventListener("click", this.bgColorFunction, false);
+			document.getAnonymousElementByAttribute(this, "anonid", "cmd_fontColor")
+				.removeEventListener("click", this.fontColorFunction, false);
 
 			// Disconnect Font face button
 			if (this.menuPopupFunction) {
@@ -288,9 +290,12 @@
 			}
 
 			// Disconnect HyperLink buttons
-			document.getAnonymousElementByAttribute(this, "anonid", "cmd_add_link").removeEventListener("click", this.addLinkFunction, true);
-			document.getAnonymousElementByAttribute(this, "anonid", "cmd_remove_link").removeEventListener("click", this.removeLinkFunction, true);
-			document.getAnonymousElementByAttribute(this, "anonid", "cmd_edit_link").removeEventListener("click", this.editLinkFunction, true);
+			document.getAnonymousElementByAttribute(this, "anonid", "cmd_add_link")
+				.removeEventListener("click", this.addLinkFunction, false);
+			document.getAnonymousElementByAttribute(this, "anonid", "cmd_remove_link")
+				.removeEventListener("click", this.removeLinkFunction, false);
+			document.getAnonymousElementByAttribute(this, "anonid", "cmd_edit_link")
+				.removeEventListener("click", this.editLinkFunction, false);
 		]]></destructor>
 			
 		<property name="content">

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -36,7 +36,12 @@
           xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<binding id="exchWebServiceEditor">
 
-    <content>
+	<!-- CSS needed to correctly display color buttons (font and background) -->
+	<resources>
+		<stylesheet src="chrome://messenger/skin/messengercompose/messengercompose.css" />
+	</resources>
+
+	<content>
 
 	<xul:vbox flex="1">
 		<xul:toolbox anonid="FormatToolbox" mode="icons">
@@ -192,7 +197,7 @@
 			flex="1"/>
 	</xul:vbox>
 
-    </content>
+	</content>
 	<implementation>
 		<constructor><![CDATA[
 			var self=this;

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -105,7 +105,7 @@
 					state="state_all"/>
 				<xul:toolbarseparator class="toolbarseparator-standard"/>
 				<xul:toolbaritem class="formatting-button">
-					<xul:stack align="enter" state="rgb(102,102,102)">
+					<xul:stack align="center" state="rgb(102,102,102)">
 						<xul:box style="background-color:#FFFFFF"
 							anonid="cmd_backgroundColor"
 							class="color-button"

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -219,9 +219,9 @@
 				this.editorElement.addEventListener("keyup", this.editorKeyPressFunction, true);
 
 				this.editorMouseOver = function(aEvent) { self.onMouseOver(aEvent);};
-				this.editorMouseOut = function(aEvent) { self.onMouseOut(aEvent);};
-
 				this.editorElement.addEventListener("mouseover", this.editorMouseOver , false);
+
+				this.editorMouseOut = function(aEvent) { self.onMouseOut(aEvent);};
 				this.editorElement.addEventListener("mouseout", this.editorMouseOut, false);
 
 				// Set default document to empty HTML content

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -374,7 +374,7 @@
 				this.functions[aStore] = {};
 			}
 			this.functions[aStore][aAnonId] = function() { self.toggleButton(aAnonId);};
-			document.getAnonymousElementByAttribute(this, "anonid", aAnonId).addEventListener("command", this.functions[aStore][aAnonId], true);
+			document.getAnonymousElementByAttribute(this, "anonid", aAnonId).addEventListener("command", this.functions[aStore][aAnonId], false);
 		]]></body>
 		</method>
 

--- a/chrome/content/exchWebServiceEditor.xml
+++ b/chrome/content/exchWebServiceEditor.xml
@@ -231,7 +231,8 @@
 			this.atomService = Components.classes["@mozilla.org/atom-service;1"]
 				.getService(Components.interfaces.nsIAtomService);
 
-			this.connectButtons("FormatToolbar");
+			this.connectAllCommandListenerToolbar("FormatToolbar");
+
 			// Connect color button
 			this.bgColorFunction = function(){ self.selectColor("cmd_backgroundColor");};
 			var bgColorElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_backgroundColor")
@@ -244,12 +245,13 @@
 			this.highlightColor = "#FFFFFF";
 			this.fontColor = "#000000";
 
-			// Fill fontfac popup menu
+			// Connect FontFace popup menu
 			this.menuPopupFunction = function(event){ self.selectFont("cmd_fontFace", event.target.value);};
 			this.menuPopup = document.getAnonymousElementByAttribute(this, "anonid", "fontFaceSelect");
 			this.menuPopup.addEventListener("command", this.menuPopupFunction, true);
 			this.fillFontFace();
 
+			// Connect HyperLink buttons
 			this.addLinkFunction = function(){ self.addLink();};
 			var addLinkElement = document.getAnonymousElementByAttribute(this, "anonid", "cmd_add_link")
 			addLinkElement.addEventListener("click", this.addLinkFunction, true);
@@ -273,12 +275,19 @@
 				this.editorElement.removeEventListener("mouseover", this.editorMouseOver , false);
 				this.editorElement.removeEventListener("mouseout", this.editorMouseOut, false);
 			}
-			this.disconnectButtons("FormatToolbar");
+
+			this.removeAllCommandListenerToolbar("FormatToolbar");
+
+			// Disconnect color button
 			document.getAnonymousElementByAttribute(this, "anonid", "cmd_backgroundColor").removeEventListener("click", this.bgColorFunction, false);
 			document.getAnonymousElementByAttribute(this, "anonid", "cmd_fontColor").removeEventListener("click", this.fontColorFunction, false);
+
+			// Disconnect Font face button
 			if (this.menuPopupFunction) {
 				this.menuPopup.removeEventListener("command", this.menuPopupFunction, false);
 			}
+
+			// Disconnect HyperLink buttons
 			document.getAnonymousElementByAttribute(this, "anonid", "cmd_add_link").removeEventListener("click", this.addLinkFunction, true);
 			document.getAnonymousElementByAttribute(this, "anonid", "cmd_remove_link").removeEventListener("click", this.removeLinkFunction, true);
 			document.getAnonymousElementByAttribute(this, "anonid", "cmd_edit_link").removeEventListener("click", this.editLinkFunction, true);
@@ -335,7 +344,7 @@
 		]]></body>
 		</method>
 
-		<method name="connectButtons">
+		<method name="connectAllCommandListenerToolbar">
 			<parameter name="aAnonId" />
 			<body><![CDATA[
 			var toolbar = document.getAnonymousElementByAttribute(this, "anonid", aAnonId);
@@ -348,14 +357,14 @@
 				var toolbarButtons = toolbar.getElementsByTagName("xul:toolbarbutton");
 				for (var i=0; i<toolbarButtons.length;i++) {
 					if ((toolbarButtons[i].hasAttribute("connect")) && (toolbarButtons[i].getAttribute("connect") === "true")) {
-						this.connectButton(toolbarButtons[i].getAttribute("anonid"), aAnonId);
+						this.addCommandListener(toolbarButtons[i].getAttribute("anonid"), aAnonId);
 					}
 				}
 			}
 		]]></body>
 		</method>
 
-		<method name="connectButton">
+		<method name="addCommandListener">
 			<parameter name="aAnonId" />
 			<parameter name="aStore" />
 			<body><![CDATA[
@@ -369,18 +378,18 @@
 		]]></body>
 		</method>
 
-		<method name="disconnectButtons">
+		<method name="removeAllCommandListenerToolbar">
 			<parameter name="aAnonId" />
 			<body><![CDATA[
 			if ((this.functions) && (this.functions[aAnonId])) {
 				for (var name in this.functions[aAnonId]) {
-					this.disconnectButton(name, aAnonId);
+					this.removeCommandListener(name, aAnonId);
 				}
 			}
 		]]></body>
 		</method>
 
-		<method name="disconnectButton">
+		<method name="removeCommandListener">
 			<parameter name="aAnonId" />
 			<parameter name="aStore" />
 			<body><![CDATA[

--- a/chrome/content/lightning-item-iframe.js
+++ b/chrome/content/lightning-item-iframe.js
@@ -151,7 +151,7 @@ exchangeEventDialog.prototype = {
 				this._document.getElementById("item-description").hidden = true;
 
 				// Display our own HTML content editor
-				itemBodyEditor.hidden = false;
+				itemBodyEditor.setAttribute("collapsed", "false");;
 
 				itemBodyEditor.setAttribute("scrollbars","yes");
 			}
@@ -256,7 +256,7 @@ exchangeEventDialog.prototype = {
 		if (aCalendar.type !== "exchangecalendar") {
 			// Hidde HTML content editor
 			this._document.getElementById("item-description").hidden = false;
-			this._document.getElementById("exchWebService-body-editor").hidden = true;
+			this._document.getElementById("exchWebService-body-editor").setAttribute("collapsed", "true");
 		}
 	},
 

--- a/chrome/content/lightning-item-iframe.js
+++ b/chrome/content/lightning-item-iframe.js
@@ -114,43 +114,21 @@ exchangeEventDialog.prototype = {
 	},
 
 	/*
-	 * This function is used to add extra informations for Exchange tasks
+	 * Adds HTML editor for exchangecalendar items
+	 * Adds extra informations for Exchange tasks
+	 *
 	 * As the same dialog is used for non-Exchange tasks and for events, this function
-	 * remove too these details when necessary.
+	 * removes too these details when necessary.
 	 */
 	updateScreen: function _updateScreen(aItem, aCalendar)
 	{
 		var item = aItem;
 
-		// If not an event and calendar type is exchangeCalendar, add Exchange task extra informations
-		if (!cal.isEvent(item)
-			&& aCalendar.type === "exchangecalendar") {
+		if (aCalendar.type === "exchangecalendar") {
 
-			// Set and display task owner
-
-			var ownerLabel = this._document.getElementById("exchWebService-owner-label");
-			if (ownerLabel) {
-				ownerLabel.setAttribute("collapsed", "false");
-				ownerLabel.value = item.owner;
-			}
-
-			// Set and display Exchange task details
-
-			this._document.getElementById("exchWebService-details-separator").hidden = false;
-			this._document.getElementById("exchWebService-details-row1").collapsed = false;
-			this._document.getElementById("exchWebService-details-row2").collapsed = false;
-			this._document.getElementById("exchWebService-details-row3").collapsed = false;
-
-			if (item.className) {
-				this._document.getElementById("exchWebService-totalWork-count").value = item.totalWork;
-				this._document.getElementById("exchWebService-actualWork-count").value = item.actualWork;
-				this._document.getElementById("exchWebService-mileage-count").value = item.mileage;
-				this._document.getElementById("exchWebService-billingInformation-count").value = item.billingInformation;
-				this._document.getElementById("exchWebService-companies-count").value = item.companies;
-			}
+			// For all item type, enable HTML editor
 
 			// Set HTML content editor
-
 			let itemBodyEditor = this._document.getElementById("exchWebService-body-editor");
 
 			// Try to read directly item body, otherwise fallback to item description property
@@ -178,37 +156,66 @@ exchangeEventDialog.prototype = {
 				itemBodyEditor.setAttribute("scrollbars","yes");
 			}
 
-			// Remove some standard inputs
+			// If not an event, add Exchange task extra informations
+			if (!cal.isEvent(item)) {
 
-			this._document.getElementById("event-grid-location-row").hidden = true;
+				// Set and display task owner
 
-			this._document.getElementById("reminder-none-separator").hidden = true;
-			this._document.getElementById("reminder-0minutes-menuitem").hidden = true;
-			this._document.getElementById("reminder-5minutes-menuitem").hidden = true;
-			this._document.getElementById("reminder-15minutes-menuitem").hidden = true;
-			this._document.getElementById("reminder-30minutes-menuitem").hidden = true;
-			this._document.getElementById("reminder-minutes-separator").hidden = true;
-			this._document.getElementById("reminder-1hour-menuitem").hidden = true;
-			this._document.getElementById("reminder-2hours-menuitem").hidden = true;
-			this._document.getElementById("reminder-12hours-menuitem").hidden = true;
-			this._document.getElementById("reminder-hours-separator").hidden = true;
-			this._document.getElementById("reminder-1day-menuitem").hidden = true;
-			this._document.getElementById("reminder-2days-menuitem").hidden = true;
-			this._document.getElementById("reminder-1week-menuitem").hidden = true;
+				var ownerLabel = this._document.getElementById("exchWebService-owner-label");
+				if (ownerLabel) {
+					ownerLabel.setAttribute("collapsed", "false");
+					ownerLabel.value = item.owner;
+				}
 
-			this._document.getElementById("timezone-starttime").hidden = true;
-			this._document.getElementById("timezone-endtime").hidden = true;
+				// Set and display Exchange task details
 
-			// Manage repeat for Exchange tasks
+				this._document.getElementById("exchWebService-details-separator").hidden = false;
+				this._document.getElementById("exchWebService-details-row1").collapsed = false;
+				this._document.getElementById("exchWebService-details-row2").collapsed = false;
+				this._document.getElementById("exchWebService-details-row3").collapsed = false;
 
-			if (this._document.getElementById("item-repeat")) {
-				this._document.getElementById("item-repeat").addEventListener("command", function() { self.updateRepeat(); }, false);
+				if (item.className) {
+					this._document.getElementById("exchWebService-totalWork-count").value = item.totalWork;
+					this._document.getElementById("exchWebService-actualWork-count").value = item.actualWork;
+					this._document.getElementById("exchWebService-mileage-count").value = item.mileage;
+					this._document.getElementById("exchWebService-billingInformation-count").value = item.billingInformation;
+					this._document.getElementById("exchWebService-companies-count").value = item.companies;
+				}
+
+				// Remove some standard inputs
+
+				this._document.getElementById("event-grid-location-row").hidden = true;
+
+				this._document.getElementById("reminder-none-separator").hidden = true;
+				this._document.getElementById("reminder-0minutes-menuitem").hidden = true;
+				this._document.getElementById("reminder-5minutes-menuitem").hidden = true;
+				this._document.getElementById("reminder-15minutes-menuitem").hidden = true;
+				this._document.getElementById("reminder-30minutes-menuitem").hidden = true;
+				this._document.getElementById("reminder-minutes-separator").hidden = true;
+				this._document.getElementById("reminder-1hour-menuitem").hidden = true;
+				this._document.getElementById("reminder-2hours-menuitem").hidden = true;
+				this._document.getElementById("reminder-12hours-menuitem").hidden = true;
+				this._document.getElementById("reminder-hours-separator").hidden = true;
+				this._document.getElementById("reminder-1day-menuitem").hidden = true;
+				this._document.getElementById("reminder-2days-menuitem").hidden = true;
+				this._document.getElementById("reminder-1week-menuitem").hidden = true;
+
+				this._document.getElementById("timezone-starttime").hidden = true;
+				this._document.getElementById("timezone-endtime").hidden = true;
+
+				// Manage repeat for Exchange tasks
+
+				if (this._document.getElementById("item-repeat")) {
+					this._document.getElementById("item-repeat").addEventListener("command", function() { self.updateRepeat(); }, false);
+				}
+
+				this.updateRepeat();
 			}
-
-			this.updateRepeat();
 		}
+
 		// For events and other calendar type, hidde back all Exchange task details, display back standard items
-		else {
+		if (cal.isEvent(item)
+			|| cal.type !== "exchangecalendar") {
 
 			// Hide Exchange task details
 
@@ -220,10 +227,6 @@ exchangeEventDialog.prototype = {
 			this._document.getElementById("exchWebService-details-row1").collapsed = true;
 			this._document.getElementById("exchWebService-details-row2").collapsed = true;
 			this._document.getElementById("exchWebService-details-row3").collapsed = true;
-
-			// HTML Task content editor
-			this._document.getElementById("item-description").hidden = false;
-			this._document.getElementById("exchWebService-body-editor").hidden = true;
 
 			// Reset standard form
 			this._document.getElementById("event-grid-location-row").hidden = false;
@@ -247,6 +250,13 @@ exchangeEventDialog.prototype = {
 			// Reset timezone start/end time
 			this._document.getElementById("timezone-starttime").hidden = false;
 			this._document.getElementById("timezone-endtime").hidden = false;
+		}
+
+		// Reset content editor when not exchangecalendar items
+		if (aCalendar.type !== "exchangecalendar") {
+			// Hidde HTML content editor
+			this._document.getElementById("item-description").hidden = false;
+			this._document.getElementById("exchWebService-body-editor").hidden = true;
 		}
 	},
 

--- a/chrome/content/lightning-item-iframe.js
+++ b/chrome/content/lightning-item-iframe.js
@@ -75,20 +75,20 @@ exchangeEventDialog.prototype = {
 				aItem.mileage = this._document.getElementById("exchWebService-mileage-count").value;
 				aItem.billingInformation = this._document.getElementById("exchWebService-billingInformation-count").value;
 				aItem.companies = this._document.getElementById("exchWebService-companies-count").value;
+			}
 
-				// Copy content from HTML editor
-				try{
-					if (this.newItem) {
-						aItem.bodyType = "HTML";
-						aItem.body = this._document.getElementById("exchWebService-body-editor").content;
-						this.newItem = false;
-					}
-					else if (aItem.bodyType === "HTML") {
-						aItem.body = this._document.getElementById("exchWebService-body-editor").content;
-					}
-				} catch(err) {
-					dump("Error saving content\n");
+			// Copy content from HTML editor
+			try{
+				if (this.newItem) {
+					aItem.bodyType = "HTML";
+					aItem.body = this._document.getElementById("exchWebService-body-editor").content;
+					this.newItem = false;
 				}
+				else if (aItem.bodyType === "HTML") {
+					aItem.body = this._document.getElementById("exchWebService-body-editor").content;
+				}
+			} catch(err) {
+				dump("Error saving content\n");
 			}
 		}
 

--- a/chrome/content/lightning-item-iframe.xul
+++ b/chrome/content/lightning-item-iframe.xul
@@ -142,7 +142,7 @@
                     flex="1"
                     insertafter="item-description"
                     disable-on-readonly="true"
-                    hidden="true"/>
+                    collapsed="true"/>
             </tabpanel>
 
         </tabpanels>


### PR DESCRIPTION
This series of patch makes a main cleanup of the HTML content editor:

- enable back correctly buttons to set color font and background font
- synchronize constructor and destructor of the XBL widget
- makes again reliable the XBL widget initialization (Fixes #28 )

It includes commits from #30 , so it will fixes #29 too.

That was needed as the fix for the initialization modified same files than the one for event contents.