### PR TITLE
Fix timezone display part 3 / 5

### DIFF
--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2832,15 +2832,13 @@ calExchangeCalendar.prototype = {
 	},
 
 	getItemsFromMemoryCache: function _getItemsFromMemoryCache(aRangeStart, aRangeEnd, aItemFilter, aListener, aExporting) {
-		if (this.debug) this.logInfo("getItemsFromMemoryCache startDate:" + aRangeStart + ", endDate:" + aRangeEnd + ", aListener:" + aListener + ", aExporting:" + aExporting);
-		var events = [];
-		var tasks = [];
+		this.logInfo("getItemsFromMemoryCache: startDate:" + aRangeStart + ", endDate:" + aRangeEnd + ", aListener:" + aListener + ", aExporting:" + aExporting);
 
-		var wantEvents = ((aItemFilter & Ci.calICalendar
-			.ITEM_FILTER_TYPE_EVENT) != 0);
+		let events = [];
+		let tasks = [];
 
-		var wantTodos = ((aItemFilter & Ci.calICalendar
-			.ITEM_FILTER_TYPE_TODO) != 0);
+		let wantEvents = ((aItemFilter & Ci.calICalendar.ITEM_FILTER_TYPE_EVENT) != 0);
+		let wantTodos = ((aItemFilter & Ci.calICalendar.ITEM_FILTER_TYPE_TODO) != 0);
 
 		// This is by using the this.itemCacheByStartDate and this.itemCacheByEndDate index.
 		if (wantEvents) {
@@ -2870,47 +2868,47 @@ calExchangeCalendar.prototype = {
 				}
 			}
 
-			for (var itemid in ids) {
-				if (this.itemCacheById[itemid]) {
-					if (isEvent(this.itemCacheById[itemid])) {
-						if (this.deleteCancelledInvitation && this.itemCacheById[itemid].isCancelled) {
-							events.push(this.itemCacheById[itemid]);
-							this.deleteItemCancelled(this.itemCacheById[itemid]);
+			// For all found ids, if item cache has it, push it to events answer
+			// Check also if invitation should be cancelled
+			for (let itemid in ids) {
+				if (this.itemCacheById[itemid]
+					&& cal.isEvent(this.itemCacheById[itemid])) {
+					events.push(this.itemCacheById[itemid]);
 
-						}
-						else {
-							events.push(this.itemCacheById[itemid]);
-						}
+					if (this.deleteCancelledInvitation
+						&& this.itemCacheById[itemid].isCancelled) {
+						this.deleteItemCancelled(this.itemCacheById[itemid]);
 					}
 				}
 			}
 		}
-		else {
-			if (wantTodos) {
-				for (var index in this.itemCacheById) {
-					if (isToDo(this.itemCacheById[index])) {
-						if ((this.deactivateTaskFollowup) && (this.itemCacheById[index].itemClass == "IPM.Note")) {
-							//Do not change order or removing from local or it will throw db error
-							//remove from offlinecache 
-							this.removeFromOfflineCache(this.itemCacheById[index]);
-							//remove from lighting GUI  
-							this.removeItemFromCache(this.itemCacheById[index]);
-						}
-						else {
-							if (((this.itemCacheById[index].isCompleted) && (aItemFilter & Ci.calICalendar.ITEM_FILTER_COMPLETED_YES))
-								|| ((!this.itemCacheById[index].isCompleted) && (aItemFilter & Ci.calICalendar.ITEM_FILTER_COMPLETED_NO))) {
-								tasks.push(this.itemCacheById[index]);
-							}
-						}
+		else if (wantTodos) {
+			let wantCompletedTodo = aItemFilter & Ci.calICalendar.ITEM_FILTER_COMPLETED_YES;
+			let wantNotCompletedTodo = aItemFilter & Ci.calICalendar.ITEM_FILTER_COMPLETED_NO;
+
+			for (let index in this.itemCacheById) {
+				if (cal.isToDo(this.itemCacheById[index])) {
+					if (this.deactivateTaskFollowup
+						&& this.itemCacheById[index].itemClass == "IPM.Note") {
+						//Do not change order or removing from local or it will throw db error
+						//remove from offlinecache
+						this.removeFromOfflineCache(this.itemCacheById[index]);
+						//remove from lighting GUI
+						this.removeItemFromCache(this.itemCacheById[index]);
+					}
+					else if ((this.itemCacheById[index].isCompleted && wantCompletedTodo)
+						|| (!this.itemCacheById[index].isCompleted && wantNotCompletedTodo)) {
+						tasks.push(this.itemCacheById[index]);
 					}
 				}
 			}
 		}
 
-		if (this.debug) this.logInfo("We got '" + events.length + "' events and  '" + tasks.length + "'  tasks from memory cache.");
+		this.logInfo("getItemsFromMemoryCache: We got '" + events.length + "' events and  '" + tasks.length + "'  tasks from memory cache.");
 		if (aListener) {
-			if (this.debug) this.logInfo("We have a listener so going to inform it.(2)");
-			if ((events.length > 0) && (wantEvents)) {
+			this.logInfo("getItemsFromMemoryCache: We have a listener so going to inform it.");
+			if (events.length > 0
+				&& wantEvents) {
 				aListener.onGetResult(this,
 					Cr.NS_OK,
 					Ci.calIEvent,
@@ -2919,7 +2917,8 @@ calExchangeCalendar.prototype = {
 					events);
 			}
 
-			if ((tasks.length > 0) && (wantTodos)) {
+			if (tasks.length > 0
+				&& wantTodos) {
 				aListener.onGetResult(this,
 					Cr.NS_OK,
 					Ci.calITodo,

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2584,42 +2584,31 @@ calExchangeCalendar.prototype = {
 		 *
 		 */
 
+		// When range start is not defined,
+		// set it to five 5 before now.
 		if (!aRangeStart) {
-			/*if (this.startDate) {
-				aRangeStart = this.startDate.clone();
-			}
-			else {
-				aRangeStart = cal.fromRFC3339("1900-01-01T00:00:00Z");
-			}*/
-
-			// We are going to request a rangestart of 5 weeks before now.
-			aRangeStart = cal.now()
-			var offset = cal.createDuration();
+			let offset = cal.createDuration();
 			offset.weeks = -5;
-			aRangeStart.addDuration(offset);
-			//dump("aRangeStart == null. Setting to:"+aRangeStart+"\n");
 
-			if ((this.startDate) && (this.startDate.compare(aRangeStart) < 0)) {
+			aRangeStart = cal.now().addDuration(offset);
+
+			// If cache already contains a bigger range, use it
+			if (this.startDate
+				&& this.startDate.compare(aRangeStart) < 0) {
 				aRangeStart = this.startDate.clone();
 			}
 
 		}
 
+		// When range end is not defined,
+		// set it to five 5 after now.
 		if (!aRangeEnd) {
-			/*if (this.endDate) {
-				aRangeEnd = this.endDate.clone();
-			}
-			else {
-				aRangeEnd = cal.fromRFC3339("3500-01-01T00:00:00Z");
-			}*/
-
-			// We are going to request a rangeend of 5 weeks after now.
-			aRangeEnd = cal.now()
-			var offset = cal.createDuration();
+			let offset = cal.createDuration();
 			offset.weeks = 5;
-			aRangeEnd.addDuration(offset);
-			//dump("aRangeEnd == null. Setting to:"+aRangeEnd+"\n");
 
+			aRangeEnd = cal.now().addDuration(offset);
+
+			// If cache already contains a bigger range, use it
 			if ((this.endDate) && (this.endDate.compare(aRangeEnd) > 0)) {
 				aRangeEnd = this.endDate.clone();
 			}

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2842,30 +2842,31 @@ calExchangeCalendar.prototype = {
 
 		// This is by using the this.itemCacheByStartDate and this.itemCacheByEndDate index.
 		if (wantEvents) {
+			let ids = {};
 
-			var startYear = aRangeStart.year;
-			var startYearday = aRangeStart.yearday;
+			let dayOffset = cal.createDuration();
+			dayOffset.days = 1;
 
-			var endYear = aRangeEnd.year;
-			var endYearday = aRangeEnd.yearday;
-			var doStop = false;
-			var ids = {};
-			while (!doStop) {
-				if ((startYear == endYear) && (startYearday == endYearday)) {
-					doStop = true;
-				}
+			let dayPos = cal.createDateTime();
+			dayPos = aRangeStart.clone();
 
-				if ((this.itemCacheByStartDate) && (this.itemCacheByStartDate[startYear]) && (this.itemCacheByStartDate[startYear][startYearday])) {
-					for (var itemid in this.itemCacheByStartDate[startYear][startYearday]) {
+			// Convert date from local timezone to UTC
+			// Given range is in local timezone and cache save in UTC
+			dayPos.isDate = false;
+			dayPos = dayPos.getInTimezone(cal.UTC());
+			dayPos.isDate = true;
+
+			// Go through all days bewteen the range start day and the range end day
+			while (dayPos.compare(aRangeEnd) < 0 ) {
+				if (this.itemCacheByStartDate
+					&& this.itemCacheByStartDate[dayPos.year]
+					&& this.itemCacheByStartDate[dayPos.year][dayPos.yearday]) {
+					for (let itemid in this.itemCacheByStartDate[dayPos.year][dayPos.yearday]) {
 						ids[itemid] = true;
 					}
 				}
 
-				startYearday++;
-				if (startYearday > 366) {
-					startYear++;
-					startYearday = 1;
-				}
+				dayPos.addDuration(dayOffset);
 			}
 
 			// For all found ids, if item cache has it, push it to events answer

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2615,20 +2615,9 @@ calExchangeCalendar.prototype = {
 
 		}
 
-		var dateChanged = false;
-		var startChanged = false;
-		var endChanged = false;
-
-		if (!this.periods) {
-			this.periods = [];
-		}
-		// Check if this requested period touches a previous seen period.
-		var periodMatch = false;
-		var i = 0;
-		while ((!periodMatch) && (i < this.periods.length)) {
-			if (this.periods[i].startDate.compare(aRangeStart) > 0) {}
-			i++;
-		}
+		let dateChanged = false;
+		let startChanged = false;
+		let endChanged = false;
 
 		if (!this.startDate) {
 			if (this.debug) this.logInfo("no startdate");

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2747,41 +2747,30 @@ calExchangeCalendar.prototype = {
 			return;
 		}
 
-		/* We started the inbox poller again in the normal place
-				if ((this.syncInboxState) && (!this.weAreInboxSyncing)) {
-					if ((this.folderBase == "calendar") && (!this.folderID)) {
-
-						// Start the inbox poller to check for meetinginvitations or cancelations.
-						this.checkInbox();
-					}
-				}
-		*/
-		// 2013-11-19 Going to request getitems period from exchange.
+		// Check if we should add items from Exchange server
 		if (!dateChanged) {
-			if (this.debug) this.logInfo("No dateChanged. Not going to request items from server.");
+			this.logInfo("getItems: No dateChanged. Not going to request items from server.");
+
 			return;
 		}
 
 		if (this.isOffline) {
-			if (this.debug) this.logInfo("We are offline. Not going to request items from server.");
+			this.logInfo("getItems: We are offline. Not going to request items from server.");
+
 			return;
 		}
 
-		// 2013-11-19 Going to request getitems period from exchange.
-		/*		if ((wantEvents) && (this.supportsEvents)) {
-					this.requestPeriod(aRangeStart, aRangeEnd, aItemFilter, aCount, false);
-				}*/
+		if (eventsRequestedAndPossible) {
 
-		if ((wantEvents) && (this.supportsEvents)) {
-			if (this.debug) this.logInfo("Requesting events from exchange server.");
-			if (((startChanged) && (oldStartDate)) || ((endChanged) && (oldEndDate))) {
-
-				//this.getItemsFromMemoryCache(aRangeStart, aRangeEnd, aItemFilter, aListener, this.exporting);
+			this.logInfo("getItems: Requesting events from exchange server.");
+			if ((startChanged && oldStartDate)
+				|| (endChanged && oldEndDate)) {
 
 				if (startChanged) {
 					if (this.debug) this.logInfo("Startdate has changed to an earlier date. Requesting difference.");
 					this.requestPeriod(aRangeStart, oldStartDate, aItemFilter, aCount, false);
 				}
+
 				if (endChanged) {
 					if (this.debug) this.logInfo("Enddate has changed to a later date. Requesting difference.");
 					this.requestPeriod(oldEndDate, aRangeEnd, aItemFilter, aCount, true);
@@ -2790,14 +2779,16 @@ calExchangeCalendar.prototype = {
 				// We need to get the period which did not change from memorycache.
 			}
 			else {
-				if (this.debug) this.logInfo("New time period. Requesting items in period.");
+				this.logInfo("New time period. Requesting items in period.");
 				this.requestPeriod(aRangeStart, aRangeEnd, aItemFilter, aCount, false);
 			}
 		}
 
-		//Request server when calendar date changed  .
-		if ((wantTodos) && (this.supportsTasks) && (startChanged || endChanged)) {
-			if (this.debug) this.logInfo("Requesting tasks from exchange server.");
+		// Request server when calendar date changed  .
+		if (tasksRequestedAndPossible
+			&& (startChanged || endChanged)) {
+			this.logInfo("getItems: Requesting tasks from exchange server.");
+
 			var self = this;
 			this.addToQueue(erFindTaskItemsRequest, {
 					user: this.user,
@@ -2818,7 +2809,7 @@ calExchangeCalendar.prototype = {
 				null);
 
 			if (!this.deactivateTaskFollowup) {
-				if (this.debug) this.logInfo("Requesting followup tasks from exchange server.");
+				this.logInfo("getItems: Requesting followup tasks from exchange server.");
 				this.addToQueue(erFindFollowupItemsRequest, {
 						user: this.user,
 						mailbox: this.mailbox,

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2727,19 +2727,20 @@ calExchangeCalendar.prototype = {
 			}
 		}
 
-		//Update calendar/task view 
+		// Update calendar/task view with items in memory
 		this.getItemsFromMemoryCache(aRangeStart, aRangeEnd, aItemFilter, aListener, this.exporting);
 
 		if (this.OnlyShowAvailability) {
-			if ((startChanged) || (endChanged)) {
-				if (startChanged) {
-					this.getOnlyFreeBusyInformation(aRangeStart, oldStartDate);
-				}
-				if (endChanged) {
-					this.getOnlyFreeBusyInformation(oldEndDate, aRangeEnd);
-				}
+			if (startChanged) {
+				this.getOnlyFreeBusyInformation(aRangeStart, oldStartDate);
 			}
-			else {
+
+			if (endChanged) {
+				this.getOnlyFreeBusyInformation(oldEndDate, aRangeEnd);
+			}
+
+			if (!startChanged
+				&& !endChanged) {
 				this.getOnlyFreeBusyInformation(aRangeStart, aRangeEnd);
 			}
 

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2550,21 +2550,6 @@ calExchangeCalendar.prototype = {
 			return;
 		}
 
-		// Calendar is not able to complete request (item type is not supported)
-		if (!this.supportsEvents
-			&& !this.supportsTasks
-			&& !this.OnlyShowAvailability) {
-
-			this.logInfo("getItems: This folder currently is not able yet to support events or tasks.");
-
-			this.notifyOperationComplete(aListener,
-				Cr.NS_OK,
-				Ci.calIOperationListener.GET,
-				null, null);
-
-			return;
-		}
-
 		let eventsRequestedAndPossible = (wantEvents && this.supportsEvents);
 		let tasksRequestedAndPossible = (wantTodos && this.supportsTasks);
 
@@ -2581,7 +2566,9 @@ calExchangeCalendar.prototype = {
 			this.logInfo("getItems: Tasks are requested and this is possible for this folder");
 		}
 
-		if ((!eventsRequestedAndPossible) && (!tasksRequestedAndPossible)) {
+		// Calendar is not able to complete request (item type is not supported)
+		if (!eventsRequestedAndPossible
+			&& !tasksRequestedAndPossible) {
 			this.logInfo("getItems: This folder is not able to support requested items.");
 
 			this.notifyOperationComplete(aListener,

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -2529,7 +2529,7 @@ calExchangeCalendar.prototype = {
 
 		this.exporting = false;
 		if (aItemFilter === Ci.calICalendar.ITEM_FILTER_ALL_ITEMS
-			&& aCount == 0
+			&& aCount === 0
 			&& aRangeStart === null
 			&& aRangeEnd === null) {
 
@@ -2598,6 +2598,7 @@ calExchangeCalendar.prototype = {
 				aRangeStart = this.startDate.clone();
 			}
 
+			this.logInfo("getItems: aRangeStart has been updated:" + aRangeStart.toString());
 		}
 
 		// When range end is not defined,
@@ -2613,53 +2614,61 @@ calExchangeCalendar.prototype = {
 				aRangeEnd = this.endDate.clone();
 			}
 
+			this.logInfo("getItems: aRangeEnd has been updated:" + aRangeEnd.toString());
 		}
+
+		if (!this.lastValidRangeStart) {
+			this.lastValidRangeStart = aRangeStart.clone();
+		}
+
+		if (!this.lastValidRangeEnd) {
+			this.lastValidRangeEnd = aRangeEnd.clone();
+		}
+
+		// Check if requested range is bigger than memory cache.
 
 		let dateChanged = false;
 		let startChanged = false;
 		let endChanged = false;
 
-		if (!this.startDate) {
-			if (this.debug) this.logInfo("no startdate");
-			this.startDate = aRangeStart.clone();
-			dateChanged = true;
-		}
-		else {
+		if (this.startDate) {
+			// New start date is before the memory cache one.
+			// memory cache is growing.
 			if (this.startDate.compare(aRangeStart) > 0) {
-				if (this.debug) this.logInfo("aRangeStart (" + aRangeStart.toString() + ") is before current startDate (" + this.startDate.toString() + ")");
-				// New start date is before old startdate. Period has grown.
+				this.logInfo("getItems: calendar has start date and aRangeStart (" + aRangeStart.toString() + ") is before current startDate (" + this.startDate.toString() + ")");
+
 				var oldStartDate = this.startDate.clone();
 				this.startDate = aRangeStart.clone();
+
 				dateChanged = true;
 				startChanged = true;
 			}
 		}
+		else {
+			this.logInfo("getItems: calendar hasn't start date, use the range start");
 
-		if (!this.endDate) {
-			if (this.debug) this.logInfo("no enddate");
-			this.endDate = aRangeEnd.clone();
+			this.startDate = aRangeStart.clone();
 			dateChanged = true;
 		}
-		else {
+
+		if (this.endDate) {
+			// New end date is after the memory cache one.
+			// Memory cache is growing.
 			if (this.endDate.compare(aRangeEnd) < 0) {
-				if (this.debug) this.logInfo("aRangeEnd (" + aRangeEnd.toString() + ") is after current endDate (" + this.endDate.toString() + ")");
-				// New end date is after old enddate. Period has grown.
+				this.logInfo("getItems: calendar has endDate and aRangeEnd (" + aRangeEnd.toString() + ") is after current endDate (" + this.endDate.toString() + ")");
+
 				var oldEndDate = this.endDate.clone();
 				this.endDate = aRangeEnd.clone();
 				dateChanged = true;
 				endChanged = true;
 			}
 		}
+		else {
+			this.logInfo("getItems: calendar hasn't end date, use the range end");
 
-		if (aRangeStart) {
-			if (this.debug) this.logInfo("getItems 5a: aRangeStart:" + aRangeStart.toString());
+			this.endDate = aRangeEnd.clone();
+			dateChanged = true;
 		}
-		if (aRangeEnd) {
-			if (this.debug) this.logInfo("getItems 5b: aRangeEnd:" + aRangeEnd.toString());
-		}
-
-		if (!this.lastValidRangeStart) this.lastValidRangeStart = aRangeStart.clone();
-		if (!this.lastValidRangeEnd) this.lastValidRangeEnd = aRangeEnd.clone();
 
 		if ((this.useOfflineCache) && (dateChanged)) {
 			if (((wantEvents) && (this.supportsEvents)) || ((wantTodos) && (this.supportsTasks))) {


### PR DESCRIPTION
mivExchangeCalendar.js: getItemsFromMemoryCache: fix looking for items in memory cache

The code before were using simple day index to go through start and end of the
range. Furthermore, it didn't managed that range were given in local timezone
and memory cache is in UTC.

This fix use Lightning tools to go through range and it converts local timezone
to UTC, so the cache is correctly read.

Fixes #67
