### PR TITLE
Enable transifex part 1 on 3

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -44,6 +44,7 @@ overlay chrome://messenger/content/folderProps.xul  chrome://exchangecalendar/co
 overlay chrome://messenger/content/messenger.xul chrome://exchangecalendar/content/rtews-overlay.xul
 
 locale exchangecalendar nl locale/exchangecalendar/nl/
+locale exchangecalendar en locale/exchangecalendar/en/
 locale exchangecalendar en-US locale/exchangecalendar/en-US/
 locale exchangecalendar fr-FR locale/exchangecalendar/fr-FR/
 locale exchangecalendar de locale/exchangecalendar/de/

--- a/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
+++ b/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
@@ -11,6 +11,7 @@ manifest exchangeAbFolderDirectory/exchangeAbFolderDirectory.manifest
 manifest exchangeAbRootDirectory/exchangeAbRootDirectory.manifest
 
 locale exchangecontacts nl    locale/exchangecontacts/nl/
+locale exchangecontacts en    locale/exchangecontacts/en/
 locale exchangecontacts en-US locale/exchangecontacts/en-US/
 locale exchangecontacts fr-FR locale/exchangecontacts/fr-FR/
 locale exchangecontacts de    locale/exchangecontacts/de/

--- a/interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeContacts.properties
+++ b/interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received contact update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeDistLists.properties
+++ b/interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received distribution list update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/interfaces/exchangeAddressBook/locale/exchangecontacts/en/addressbookOverlay.dtd
+++ b/interfaces/exchangeAddressBook/locale/exchangecontacts/en/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Add Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.addaccount "This will add a new Exchange contact folder">
+
+<!ENTITY toolbar.button.label.deleteaccount "Remove Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.deleteaccount "This will remove an existing Exchange contact folder">
+
+<!ENTITY deleteExchangeCmd.label "Remove Exchange contact folder">
+
+

--- a/interfaces/exchangeAddressBook/locale/exchangecontacts/en/exchangeContactSettings.dtd
+++ b/interfaces/exchangeAddressBook/locale/exchangecontacts/en/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting request">
+
+<!ENTITY label.ecExchangeSettings.title "Name in list:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Refresh interval in seconds:">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Add global address list to search results.">
+

--- a/locale/exchangecalendar/en/attachments-view.dtd
+++ b/locale/exchangecalendar/en/attachments-view.dtd
@@ -1,0 +1,2 @@
+<!ENTITY exchWebServie.add.attachment.button.label "Attachments">
+

--- a/locale/exchangecalendar/en/browseFolder.dtd
+++ b/locale/exchangecalendar/en/browseFolder.dtd
@@ -1,0 +1,12 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY browsefolder.title "Browse folders">
+
+<!ENTITY treecol.label.foldername "Folder name">
+<!ENTITY treecol.label.folderclass "Folder class">
+
+
+
+
+

--- a/locale/exchangecalendar/en/calExchangeCalendar.properties
+++ b/locale/exchangecalendar/en/calExchangeCalendar.properties
@@ -1,0 +1,49 @@
+displayName=Exchange 2007/2010 Calendar and Tasks Provider
+
+resetEventMessage=Calendar "%1$S" has been reset.
+addTaskEventMessage=Added task "%1$S" (%2$S).
+addCalendarEventMessage=Added appointment "%1$S" (%2$S).
+ewsErrorEventMessage=Error in communication with EWS server for "%1$S". Error: %2$S, Code: %3$S.
+updateCalendarEventMessage=Appointment "%1$S" has been modified (%2$S).
+updateTaskEventMessage=Task "%1$S" has been modified (%2$S).
+deleteCalendarEventMessage=Appointment "%1$S" has been removed (%2$S).
+deleteTaskEventMessage=Task "%1$S" has been removed (%2$S).
+syncFolderEventMessage="%4$S": Received updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxRequests="%4$S": Inbox received meeting invitation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxCancelations="%4$S": Inbox received meeting cancelation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxResponses="%4$S": Inbox received meeting response updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+ewsMeetingResponsEventMessage=Meeting request "%1$S" answered with "%2$S" (%3$S). Your message:
+
+ecErrorServerCheck=Error while checking with server: %1$S (%2$S)
+ecErrorAutodiscovery=Error during autodiscovery: %1$S (%2$S)
+ecErrorAutodiscoveryURLInvalid=It was not possible to find settings through autodiscovery using the domain name part of the mailbox (%1$S).\nUsually this means there is not an autodiscovery server defined with the domain name part as hostname.
+ecErrorServerCheckURLInvalid=Server "%1$S" does not exist.
+ecErrorServerAndMailboxCheck=Error during checking of server and mailbox: %1$S (Code: %2$S)
+
+updateUserPrefs1=User preferences updated for new version (since 0.7.26)
+
+autoRemoveConfirmedInvitationOnCancellation=Confirmed appointment "%1$S" has been canceled and was automatically removed as specified by user settings (%2$S).
+
+sendAutoRespondMeetingRequestMessage=Meeting request "%1$S" has been automatically answered as specified by the user settings (%2$S).
+
+ecLoadingOofSettings=(Retrieving data)
+ecLoadedOofSettings=(Data retrieved)
+ecErrorLoadingOofSettings=Error during loading of out of office settings. Code: %2$S, Message: %1$S.
+ecSavingOofSettings=(Saving data)
+ecSavedOofSettings=(Data saved)
+ecErrorSavingOofSettings=Error during saving of out of office settings. Code: %2$S, Message: %1$S.
+
+
+exchWebService.PidLidTaskHistory.duedate.changed=Due date was changed
+exchWebService.PidLidTaskHistory.some.property.changed=A property was changed
+exchWebService.PidLidTaskHistory.accepted=Task accepted by %1$S
+exchWebService.PidLidTaskHistory.rejected=Task rejected by %1$S
+exchWebService.PidLidTaskHistory.assigned=Task assigned to %1$S
+exchWebService.PidLidTaskHistory.no.changes=No changes
+
+ecErrorServerAndMailboxCheckFolderNotFound=Either you do not have read permission on the selected mailbox or the mailbox is incorrect.\n\nWhen the mailbox is corrected you might have permissions to view the busy/tentative/OOO user availability status for its calendar.\n\n(%2$S: %1$S)
+
+tooltipCalendarDisconnected=The calendar %1$S is not connected to the Exchange server\n(Reason: %2$S).
+tooltipCalendarDisconnectedReadOnly=The calendar %1$S is not connected to the Exchange server and is read only\n(Reason: %2$S).
+tooltipCalendarConnected=The calendar %1$S is connected to the Exchange server.
+tooltipCalendarConnectedReadOnly=The calendar %1$S is connected to the Exchange server and is readonly.

--- a/locale/exchangecalendar/en/calendar-calendars-list.dtd
+++ b/locale/exchangecalendar/en/calendar-calendars-list.dtd
@@ -1,0 +1,5 @@
+<!ENTITY calendar.context.exchange.convert.label "Convert to Exchange 2007/2010 Calendar and Tasks Add-on">
+<!ENTITY calendar.context.exchange.properties.label "Exchange (EWS) properties">
+<!ENTITY calendar.context.exchange.oof.settings.label "Out of office settings">
+<!ENTITY calendar.context.exchange.clone.settings.label "Clone settings to new calendar">
+<!ENTITY calendar.context.exchange.delegate.calendar.settings.label "Delegate calendar">

--- a/locale/exchangecalendar/en/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/en/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required attendee">
+<!ENTITY optional.attendee.label "Optional attendee">

--- a/locale/exchangecalendar/en/delegate-calendar-dialog.dtd
+++ b/locale/exchangecalendar/en/delegate-calendar-dialog.dtd
@@ -1,0 +1,25 @@
+ 
+<!ENTITY  label.delegateCalendar.cancelbutton "Cancel">
+<!ENTITY  label.delegateCalendar.userEmail "Email">
+<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl "Deliver meeting requests">
+
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly "Delegates Only">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe "Delegates and Me">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo "Delegates and Send Notifications to Me">
+
+<!ENTITY  label.delegateCalendar.permission "Permission">
+<!ENTITY  menuitem.delegateCalendar.permission.author "Author">
+<!ENTITY  menuitem.delegateCalendar.permission.editor "Editor">
+<!ENTITY  menuitem.delegateCalendar.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegateCalendar.permission.none "None">
+
+<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy "Receive copies Of meeting messages" >
+<!ENTITY  label.delegateCalendar.permission.viewPrivateItems "View private items" >
+
+
+<!ENTITY  delegateCalendar.permission.description.author "Read and create items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.editor "Read, create, and modify items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.reviewer "Read items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.none "No access permissions to the calendar folder." >
+
+<!ENTITY  delegateCalendar.permission.details.label "Permission details: " >

--- a/locale/exchangecalendar/en/delegate-folder.dtd
+++ b/locale/exchangecalendar/en/delegate-folder.dtd
@@ -1,0 +1,45 @@
+ 
+<!ENTITY  label.delegatefolder.cancelbutton "Cancel">
+<!ENTITY  label.delegatefolder.userEmail "Email">
+ 
+<!ENTITY  label.delegatefolder.permissionLevel "Permission level">
+<!ENTITY  label.delegatefolder.userboxcolumn1 "User"> 
+<!ENTITY  label.delegatefolder.userboxcolumn2 "Permissions"> 
+
+<!ENTITY  menuitem.delegatefolder.permission.author "Author">
+<!ENTITY  menuitem.delegatefolder.permission.editor "Editor">
+<!ENTITY  menuitem.delegatefolder.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegatefolder.permission.none "None">
+<!ENTITY  menuitem.delegatefolder.permission.owner "Owner" > 
+<!ENTITY  menuitem.delegatefolder.permission.publishingEditor "PublishingEditor" >
+<!ENTITY  menuitem.delegatefolder.permission.publishingAuthor "PublishingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.noneditingAuthor "NoneditingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.contributor "Contributor" >
+<!ENTITY  menuitem.delegatefolder.permission.custom "Custom" >
+                            
+<!ENTITY  delegatefolder.permission.description.author "Read and create items in the folder." >
+<!ENTITY  delegatefolder.permission.description.editor "Read, create, and modify items in the folder." >
+<!ENTITY  delegatefolder.permission.description.reviewer "Read items in the folder." >
+<!ENTITY  delegatefolder.permission.description.none "No access permissions to the folder." >
+
+ <!ENTITY  delegatefolder.permission.details.caption "Permission "> 
+
+<!ENTITY  delegatefolder.tab.msg.label  "No calendar or task found for this mail account.">
+<!ENTITY  delegatefolder.tab.name  "Exchange folder sharing">
+
+<!ENTITY  delegatefolder.permissions.none  "None">
+<!ENTITY  delegatefolder.permissions.own  "Own items">
+<!ENTITY  delegatefolder.permissions.all  "All items">
+<!ENTITY  delegatefolder.permissions.full  "Full details">
+
+<!ENTITY  delegatefolder.permissions.cancreateitems  "Create items">
+<!ENTITY  delegatefolder.permissions.cancreatesubfolders  "Create subfolders">
+<!ENTITY  delegatefolder.permissions.isfolderowner  "Folder owner">
+<!ENTITY  delegatefolder.permissions.isfoldervisible  "Folder visible">
+<!ENTITY  delegatefolder.permissions.isfoldercontact  "Folder contact">
+<!ENTITY  delegatefolder.permissions.edititems  "Edit items">
+<!ENTITY  delegatefolder.permissions.deleteitems  "Delete items">
+<!ENTITY  delegatefolder.permissions.readitems  "Read items">  
+ 
+<!ENTITY  delegatefolder.permissions.true  "True">
+<!ENTITY  delegatefolder.permissions.false  "False">

--- a/locale/exchangecalendar/en/ecCalendarCreation.dtd
+++ b/locale/exchangecalendar/en/ecCalendarCreation.dtd
@@ -1,0 +1,5 @@
+<!ENTITY exchange1.description "Exchange/Windows Active Directory settings">
+<!ENTITY exchange.cache.label "Use offline cache">
+
+
+

--- a/locale/exchangecalendar/en/exchangeCloneSettings.dtd
+++ b/locale/exchangecalendar/en/exchangeCloneSettings.dtd
@@ -1,0 +1,6 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.ecExchangeSettings.title "New description:">
+
+

--- a/locale/exchangecalendar/en/exchangeReminderDialog.dtd
+++ b/locale/exchangecalendar/en/exchangeReminderDialog.dtd
@@ -1,0 +1,4 @@
+<!ENTITY exchWebService.reminder.relation.origin.label "before the event starts">
+
+
+

--- a/locale/exchangecalendar/en/exchangeSettings.dtd
+++ b/locale/exchangecalendar/en/exchangeSettings.dtd
@@ -1,0 +1,54 @@
+<!ENTITY label.acceptbutton "Save and reset">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY ecsettings.title "EWS calendar and mail settings">
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting requests">
+<!ENTITY ecsettings.tab.calendarfolderproperties "Folder properties">
+
+<!ENTITY label.ecExchangeSettings.title "Settings for calendar:">
+
+<!ENTITY label.poll.inbox "Poll inbox for requests, changes and cancellations.">
+<!ENTITY label.poll.inbox.interval "Frequency (in seconds) to poll inbox:">
+<!ENTITY label.poll.calendar.interval "Frequency (in seconds) to poll calendar:">
+
+<!ENTITY label.nomeetingrequestsettings "You cannot set a meeting request because you did not select the main calendar for the mailbox">
+
+<!ENTITY label.autorespond.meetingrequest "Automatically respond to a new invitation with ">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.autoremove.invitation_cancellation1 "Automatically remove the invitation and accompanying cancelation message if you did not yet respond to the invitation request.">
+<!ENTITY label.autoremove.invitation_cancellation2 "Automatically remove a confirmed invitation when you receive a cancelation message.">
+
+<!ENTITY label.autoremove.invitation_response1 "Automatically remove a response from others to a meeting invitation of which you are not the organizer.">
+
+<!ENTITY label.doautorespond.meetingrequest.message "Send the following message with responses instead of asking for a message.">
+<!ENTITY label.autorespond.meetingrequest.message "Your message:">
+
+<!ENTITY treecol.label.userid "User ID">
+<!ENTITY treecol.label.email "Email">
+
+
+<!ENTITY ecsettings.tab.offlineCachingproperties "Offline caching">
+
+<!ENTITY label.offlineCacheproperties.cachingStartDate "Start date of caching:">
+<!ENTITY label.offlineCacheproperties.cachingEndDate "End date of caching:">
+<!ENTITY label.offlineCacheproperties.totalEvents "Total number of events cached:">
+<!ENTITY label.offlineCacheproperties.totalTasks "Total number of tasks cached:">
+
+<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate "Number of months to cache items prior to today:">
+<!ENTITY label.offlineCacheproperties.monthsBeforeEndDate "Number of months to cache items after today:">
+
+<!ENTITY button.offlineCacheproperties.clearCache "Clear offline cached data">
+<!ENTITY ecsettings.tab.autoprocessingproperties "Automatic processing">
+<!ENTITY ecsettings.tab.mailitemsProperties "EWS settings (mail)">
+
+<!ENTITY label.syncmailitems.interval "Delay syncing mail items (tags, etc.)">
+<!ENTITY label.autoprocessingproperties.deletecancelleditems "Automatically remove canceled events">
+<!ENTITY label.autoprocessingproperties.markeventtentative "Automatically mark event as tentative and send response to organizer">
+<!ENTITY label.syncmailitems.active "Keep enabled syncing mail items (tags, etc.)">
+
+<!ENTITY label.syncfollowup.deactivtate "Disable followup task">
+ 

--- a/locale/exchangecalendar/en/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/en/exchangeSettingsOverlay.dtd
@@ -1,0 +1,56 @@
+<!ENTITY ecautodiscover "Use Exchange's autodiscovery function.">
+<!ENTITY ecfolderbase.label "Folder base:">
+<!ENTITY ecfolderpath.label "Path below folder base:">
+<!ENTITY ecfolderidofshare.label "Share Folder ID:">
+<!ENTITY exchWebServices.SharedFolderID.label "Shared display name:">
+
+<!ENTITY menuitem.label.ecfolderbase.calendar "Calendar folder">
+<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot "Public folders">
+<!ENTITY menuitem.label.ecfolderbase.inbox "Mail inbox folder">
+<!ENTITY menuitem.label.ecfolderbase.voicemail "Voice mail folder">
+<!ENTITY menuitem.label.ecfolderbase.msgfolderroot "Message folder root">
+<!ENTITY menuitem.label.ecfolderbase.root "Root of the mailbox">
+<!ENTITY menuitem.label.ecfolderbase.tasks "Tasks folder">
+
+<!ENTITY menuitem.label.ecfolderbase.contacts "Contacts folder">
+<!ENTITY menuitem.label.ecfolderbase.deleteditems "Deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.drafts "Drafts folder">
+<!ENTITY menuitem.label.ecfolderbase.journal "Journal folder">
+<!ENTITY menuitem.label.ecfolderbase.notes "Notes folder">
+<!ENTITY menuitem.label.ecfolderbase.outbox "Mail outbox folder">
+<!ENTITY menuitem.label.ecfolderbase.sentitems "Sent items folder">
+<!ENTITY menuitem.label.ecfolderbase.junkemail "Junk email folder">
+<!ENTITY menuitem.label.ecfolderbase.searchfolders "Search folders folder">
+<!ENTITY menuitem.label.ecfolderbase.version2010 "-- Options below are only for Exchange 2010 --">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot "Dumpster root folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions "Dumpster deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion "Dumpster versions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges "Dumpster purges folder">
+<!ENTITY menuitem.label.ecfolderbase.archiveroot "Root archive folder">
+<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot "Root archive message folder">
+<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems "Archive deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot "Archive recoverable items root folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsdeletions "Archive recoverable items deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsversions "Archive recoverable items versions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemspurges "Archive recoverable items purges folder">
+
+<!ENTITY button.label.autodiscovercheck "Perform autodiscovery">
+<!ENTITY button.label.serverandmailboxcheck "Check server and mailbox">
+<!ENTITY button.label.servercheck "Check server and account">
+
+<!ENTITY ecmailbox.label "Primary email address:">
+<!ENTITY ecmailbox.tooltip "If you do not specify a mailbox you will only have access to public folders.">
+<!ENTITY ecwindowsuser.label "Username:">
+<!ENTITY ecwindowsdomain.label "Domain name:">
+<!ENTITY ecwindowspassword.label "Password:">
+
+<!ENTITY button.label.folderpathcheck "Check">
+<!ENTITY button.label.folderbrowse "Browse">
+
+<!ENTITY exchWebServices.UserAvailability.label "Only user availability status for the mailbox's calendar will be visible.">
+
+<!ENTITY exchWebServices.exchtype.label "Exchange type">
+<!ENTITY exchWebServices.hostexch.label "Hosted Exchange">
+<!ENTITY exchWebServices.365exch.label "Microsoft Office 365">
+<!ENTITY exchWebServices.detail.label "Details">
+ 

--- a/locale/exchangecalendar/en/extra-priority.dtd
+++ b/locale/exchangecalendar/en/extra-priority.dtd
@@ -1,0 +1,18 @@
+<!ENTITY prefwindow.title "Extras">
+<!ENTITY general.label  "General"> 
+<!ENTITY about.label "About"> 
+ 
+<!ENTITY about.description.label "Enhanced Features for Thunderbird and SeaMonkey applications">
+<!ENTITY iconify.label "Display priority icons only"> 
+<!ENTITY shadeHigh.label "Color background for high-priority messages">
+<!ENTITY shadeLow.label "Color background for low-priority messages">
+<!ENTITY tagImportant.label "Automatically tag high-priority mail as important">
+ 
+<!ENTITY highestColor.label "Highest">
+
+<!ENTITY highColor.label "High">
+<!ENTITY lowColor.label "Low">
+<!ENTITY lowestColor.label "Lowest">
+ 
+<!ENTITY prioritycolor  "Custom Color">
+<!ENTITY pref.color "Color preferences:">

--- a/locale/exchangecalendar/en/invitationResponse.dtd
+++ b/locale/exchangecalendar/en/invitationResponse.dtd
@@ -1,0 +1,20 @@
+<!ENTITY label.acceptbutton "Confirm change">
+<!ENTITY label.cancelbutton "Cancel change">
+
+<!ENTITY description.invitationResponse "Confirm change of your meeting response.">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY label.messageReponseBody "Response message:">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.proposenewtime.title "Propose new time (>= Exchange2013)">
+<!ENTITY label.proposenewtime.start "Start time">
+<!ENTITY label.proposenewtime.end "End time">

--- a/locale/exchangecalendar/en/inviteStyle.dtd
+++ b/locale/exchangecalendar/en/inviteStyle.dtd
@@ -1,0 +1,2 @@
+<!ENTITY label.inviteCol "Calendar invite">
+<!ENTITY tooltip.inviteCol "Sort by invitation">

--- a/locale/exchangecalendar/en/lightning-item-iframe.dtd
+++ b/locale/exchangecalendar/en/lightning-item-iframe.dtd
@@ -1,0 +1,7 @@
+<!ENTITY exchWebService.owner.label "Owner:">
+<!ENTITY exchWebService.totalWork.label "Total work:">
+<!ENTITY exchWebService.actualWork.label "Actual work:">
+<!ENTITY exchWebService.mileage.label "Mileage:">
+<!ENTITY exchWebService.billingInformation.label "Billing information:">
+<!ENTITY exchWebService.companies.label "Company:">
+

--- a/locale/exchangecalendar/en/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/en/manageEWSAccounts.dtd
@@ -1,0 +1,16 @@
+<!ENTITY label.acceptbutton "Close">
+
+<!ENTITY exchWebService.manageEWSAccounts.newAccount.button "Add account">
+<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button "Remove account">
+<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Save settings">
+
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Use Exchange's autodiscovery function.">
+<!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailbox name:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Username:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domain name:">
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button "Perform autodiscovery">
+<!ENTITY exchWebService.manageEWSAccounts.servercheck.button "Check server and account">
+<!ENTITY exchWebService.manageEWSAccounts.name.label "Name:">
+
+<!ENTITY exchWebService.manageEWSAccounts.menuitem "Exchange Web Services accounts">
+

--- a/locale/exchangecalendar/en/messenger_task_delegation.dtd
+++ b/locale/exchangecalendar/en/messenger_task_delegation.dtd
@@ -1,0 +1,6 @@
+<!ENTITY exchWebService.task.delegation.owner.name "Task owner">
+<!ENTITY exchWebService.task.delegation.delegator.name "Task delegator">
+<!ENTITY exchWebService.task.delegation.accept.button "Accept">
+<!ENTITY exchWebService.task.delegation.decline.button "Decline">
+<!ENTITY exchWebService.task.delegation.lastUpdateDate "Last change on">
+

--- a/locale/exchangecalendar/en/oofSettings.dtd
+++ b/locale/exchangecalendar/en/oofSettings.dtd
@@ -1,0 +1,26 @@
+<!ENTITY title.oofsettings "Out of office settings">
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Close">
+<!ENTITY label.oofsettings.title "Out of office settings for:">
+
+<!ENTITY label.oofstatus "Out of office status:">
+
+<!ENTITY label.externalaudience "To which external persons do you want to send out of office messages: ">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none "To nobody">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known "Only to persons in my contact list">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all "To everybody">
+
+<!ENTITY button.label.internal "Internal message">
+<!ENTITY button.label.external "External message">
+<!ENTITY label.internalreply "Message that will be sent to people within my organization:">
+<!ENTITY label.externalreply "Message that will be sent to people outside my organization:">
+
+<!ENTITY menuitem.label.exchWebService-oof-status.disabled "Disabled">
+<!ENTITY menuitem.label.exchWebService-oof-status.enabled "Enabled">
+
+<!ENTITY checkbox.label.exchWebService-oof-scheduled "Only enabled in specified time frame:">
+<!ENTITY label.hbox-oof-scheduled-startTime "Start time:">
+<!ENTITY label.hbox-oof-scheduled-endTime "End time:">
+
+
+

--- a/locale/exchangecalendar/en/preInvitationResponse.dtd
+++ b/locale/exchangecalendar/en/preInvitationResponse.dtd
@@ -1,0 +1,14 @@
+<!ENTITY dialog.exchWebService.preInvitationResponse.title "How do you want to react?">
+<!ENTITY label.acceptbutton "OK">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY radio.label.exchWebService.preInvitationResponse.edit "Edit the response before sending.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow "Send the response now.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend "Don't send a response.">
+

--- a/locale/exchangecalendar/en/preferences.dtd
+++ b/locale/exchangecalendar/en/preferences.dtd
@@ -1,0 +1,48 @@
+<!ENTITY exchangeWebService.paneAccounts.title "Exchange (EWS)">
+<!ENTITY exchangeWebService.paneDebug.title "Logging">
+
+<!ENTITY exchangeWebService.preferences.tab.accounts "Accounts">
+<!ENTITY exchangeWebService.preferences.tab.debug "Logging">
+<!ENTITY exchangeWebService.preference.debug.file "Log file location:">
+<!ENTITY exchangeWebService.preference.network.debug.caption "Communication with Exchange server:">
+<!ENTITY exchangeWebService.preference.debug.log.label "Log information to the console and/or a file">
+<!ENTITY exchangeWebService.preference.debug.file.button "Browse">
+<!ENTITY exchangeWebService.preference.network.debug.label "Log communication with Exchange server">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.authentication.debug.label "Log communication progress information (e.g., Authentication)">
+<!ENTITY exchangeWebService.preference.authentication.showpassword.label "Show password in clear text in log file.">
+
+<!ENTITY exchangeWebService.preference.contacts.debug.caption "Addressbook/Contacts:">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.contacts.debug.label "Log info about addressbook/contacts part">
+
+<!ENTITY exchangeWebService.preferences.titleWin "Exchange (EWS) Preferences">
+
+<!ENTITY exchangeWebService.preference.core.debug.caption "Core provider object:">
+<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = None, 1 = Basic information, 2 = Extended information">
+
+<!ENTITY exchangeWebService.preferences.tab.cache "Caching">
+<!ENTITY exchangeWebService.preference.cache.memory.label "Minimal temporary memory cache">
+<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label "Number of days to download before start date of program:">
+<!ENTITY exchangeWebService.preference.cache.memory.startupAfter.label "Number of days to download after start date of program:">
+
+<!ENTITY exchangeWebService.preferences.tab.others "Others">
+<!ENTITY exchangeWebService.preference.others.prefs.label "Communication preferences:">
+<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label "Maximum number of retries for exchange communication:">
+
+<!ENTITY exchangeWebService.preference.updateFunction.label "Add-on update function:">
+<!ENTITY exchangeWebService.preference.checkForUpdates.label "Automatically check for a new add-on version online when starting Thunderbird.">
+<!ENTITY exchangeWebService.preference.warnForUpdates.label "Show warning when a new version is available so you can easily install it.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximum number of simultaneous request to exchange server:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
+<!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
+
+<!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
+<!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
+<!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/locale/exchangecalendar/en/rtews.dtd
+++ b/locale/exchangecalendar/en/rtews.dtd
@@ -1,0 +1,15 @@
+ <!ENTITY rtews.selectaccountdesc "Select Microsoft Exchange mail account for which to configure.">
+ <!ENTITY rtews.accconfigured "Account already configured">
+ <!ENTITY rtews.dicoverdesc "You may choose to autodiscover the Exchange Web Services (EWS) URL or configure it manually">
+ <!ENTITY rtews.dicoverdesc2 "To configure it manually enter the URL in the field below.">
+ <!ENTITY rtews.autodiscover "Autodiscover">
+ <!ENTITY rtews.doautodicover "Do autodiscovery">
+ <!ENTITY rtews.manual "Manual">
+ <!ENTITY rtews.test "Click here to verify the EWS URL">
+ <!ENTITY rtews.msexchewsurl "Verified EWS URL. Click Finish to complete the configuration">
+ <!ENTITY rtews.selectaccount "Select account">
+ <!ENTITY rtews.configure.label "Configure...">
+ <!ENTITY rtews.rtforexch "Remote tagger for Microsoft Exchange">
+ <!ENTITY rtews.confirmAccDetail "Confirm following account details">
+ <!ENTITY rtews.username "Username">
+ <!ENTITY rtews.domain "Domain">

--- a/locale/exchangecalendar/en/rtews.properties
+++ b/locale/exchangecalendar/en/rtews.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger  
+rtews.tagAddError=There was an error creating the tag for the category

--- a/locale/exchangecalendar/en/selectEWSUrl.dtd
+++ b/locale/exchangecalendar/en/selectEWSUrl.dtd
@@ -1,0 +1,9 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY description.selectews "Choose an EWS server from the list which is suitable for your current location.">
+<!ENTITY label.selectews "EWS server list:">
+
+
+
+

--- a/locale/exchangecalendar/en/sendUpdateTo.dtd
+++ b/locale/exchangecalendar/en/sendUpdateTo.dtd
@@ -1,0 +1,9 @@
+<!ENTITY title.sendupdateto "To whom do you want to send this update?">
+<!ENTITY label.acceptbutton "Execute">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY label.calendaritem.title "Send update for meeting:">
+
+<!ENTITY radio.label.sendtonone "Send to nobody.">
+<!ENTITY radio.label.sendtoall "Send to everyone invited.">
+<!ENTITY radio.label.sendtochanged "Send only to added or removed persons.">
+

--- a/locale/exchangecalendar/en/sharedCalendarParser.dtd
+++ b/locale/exchangecalendar/en/sharedCalendarParser.dtd
@@ -1,0 +1,3 @@
+<!ENTITY exchWebService_vbox_label "Detected an Exchange sharing invitation">
+<!ENTITY exchWebService_button_label_add_calendar "Add calendar">
+

--- a/locale/exchangecalendar/en/timezonePreference.dtd
+++ b/locale/exchangecalendar/en/timezonePreference.dtd
@@ -1,0 +1,1 @@
+<!ENTITY calendar.timezone.local.auto.label  "Automatically change timezone">


### PR DESCRIPTION
Transifex exchangecalendar project has been setup to use `en` language as source.

To avoid to do a mix between `en-US` and `en` through Github and Transifex, I've copied all `en-US` files to the `en` locale. So both services use same structure.