### PR TITLE
Enable transifex part 3 on 3

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,3 @@
+[main]
+host = https://www.transifex.com
+

--- a/.tx/config
+++ b/.tx/config
@@ -13,3 +13,15 @@ source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/exchange
 source_lang = en
 type = DTD
 
+[exchangecalendar.addressbook-ExchangeContacts]
+file_filter = interfaces/exchangeAddressBook/locale/exchangecontacts/<lang>/ExchangeContacts.properties
+source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeContacts.properties
+source_lang = en
+type = MOZILLAPROPERTIES
+
+[exchangecalendar.addressbook-ExchangeDistLists]
+file_filter = interfaces/exchangeAddressBook/locale/exchangecontacts/<lang>/ExchangeDistLists.properties
+source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/ExchangeDistLists.properties
+source_lang = en
+type = MOZILLAPROPERTIES
+

--- a/.tx/config
+++ b/.tx/config
@@ -1,3 +1,15 @@
 [main]
 host = https://www.transifex.com
 
+[exchangecalendar.addressbook-addressbookOverlay]
+file_filter = interfaces/exchangeAddressBook/locale/exchangecontacts/<lang>/addressbookOverlay.dtd
+source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/addressbookOverlay.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.addressbook-exchangeContactSettings]
+file_filter = interfaces/exchangeAddressBook/locale/exchangecontacts/<lang>/exchangeContactSettings.dtd
+source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/exchangeContactSettings.dtd
+source_lang = en
+type = DTD
+

--- a/.tx/config
+++ b/.tx/config
@@ -25,3 +25,153 @@ source_file = interfaces/exchangeAddressBook/locale/exchangecontacts/en/Exchange
 source_lang = en
 type = MOZILLAPROPERTIES
 
+[exchangecalendar.attachments-view]
+file_filter = locale/exchangecalendar/<lang>/attachments-view.dtd
+source_file = locale/exchangecalendar/en/attachments-view.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.browseFolder]
+file_filter = locale/exchangecalendar/<lang>/browseFolder.dtd
+source_file = locale/exchangecalendar/en/browseFolder.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.exchangeCloneSettings]
+file_filter = locale/exchangecalendar/<lang>/exchangeCloneSettings.dtd
+source_file = locale/exchangecalendar/en/exchangeCloneSettings.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.exchangeReminderDialog]
+file_filter = locale/exchangecalendar/<lang>/exchangeReminderDialog.dtd
+source_file = locale/exchangecalendar/en/exchangeReminderDialog.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.messenger_task_delegation]
+file_filter = locale/exchangecalendar/<lang>/messenger_task_delegation.dtd
+source_file = locale/exchangecalendar/en/messenger_task_delegation.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.sendUpdateTo]
+file_filter = locale/exchangecalendar/<lang>/sendUpdateTo.dtd
+source_file = locale/exchangecalendar/en/sendUpdateTo.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.timezonePreference]
+file_filter = locale/exchangecalendar/<lang>/timezonePreference.dtd
+source_file = locale/exchangecalendar/en/timezonePreference.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.invitationResponse]
+file_filter = locale/exchangecalendar/<lang>/invitationResponse.dtd
+source_file = locale/exchangecalendar/en/invitationResponse.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.lightning-item-iframe]
+file_filter = locale/exchangecalendar/<lang>/lightning-item-iframe.dtd
+source_file = locale/exchangecalendar/en/lightning-item-iframe.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.calendar-calendars-list]
+file_filter = locale/exchangecalendar/<lang>/calendar-calendars-list.dtd
+source_file = locale/exchangecalendar/en/calendar-calendars-list.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.calendar-summary-dialog]
+file_filter = locale/exchangecalendar/<lang>/calendar-summary-dialog.dtd
+source_file = locale/exchangecalendar/en/calendar-summary-dialog.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.delegate-calendar-dialog]
+file_filter = locale/exchangecalendar/<lang>/delegate-calendar-dialog.dtd
+source_file = locale/exchangecalendar/en/delegate-calendar-dialog.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.delegate-folder]
+file_filter = locale/exchangecalendar/<lang>/delegate-folder.dtd
+source_file = locale/exchangecalendar/en/delegate-folder.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.exchangeSettings]
+file_filter = locale/exchangecalendar/<lang>/exchangeSettings.dtd
+source_file = locale/exchangecalendar/en/exchangeSettings.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.extra-priority]
+file_filter = locale/exchangecalendar/<lang>/extra-priority.dtd
+source_file = locale/exchangecalendar/en/extra-priority.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.inviteStyle]
+file_filter = locale/exchangecalendar/<lang>/inviteStyle.dtd
+source_file = locale/exchangecalendar/en/inviteStyle.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.manageEWSAccounts]
+file_filter = locale/exchangecalendar/<lang>/manageEWSAccounts.dtd
+source_file = locale/exchangecalendar/en/manageEWSAccounts.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.oofSettings]
+file_filter = locale/exchangecalendar/<lang>/oofSettings.dtd
+source_file = locale/exchangecalendar/en/oofSettings.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.preInvitationResponse]
+file_filter = locale/exchangecalendar/<lang>/preInvitationResponse.dtd
+source_file = locale/exchangecalendar/en/preInvitationResponse.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.preferences]
+file_filter = locale/exchangecalendar/<lang>/preferences.dtd
+source_file = locale/exchangecalendar/en/preferences.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.rtews]
+file_filter = locale/exchangecalendar/<lang>/rtews.dtd
+source_file = locale/exchangecalendar/en/rtews.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.selectEWSUrl]
+file_filter = locale/exchangecalendar/<lang>/selectEWSUrl.dtd
+source_file = locale/exchangecalendar/en/selectEWSUrl.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.sharedCalendarParser]
+file_filter = locale/exchangecalendar/<lang>/sharedCalendarParser.dtd
+source_file = locale/exchangecalendar/en/sharedCalendarParser.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.ecCalendarCreation]
+file_filter = locale/exchangecalendar/<lang>/ecCalendarCreation.dtd
+source_file = locale/exchangecalendar/en/ecCalendarCreation.dtd
+source_lang = en
+type = DTD
+
+[exchangecalendar.exchangeSettingsOverlay]
+file_filter = locale/exchangecalendar/<lang>/exchangeSettingsOverlay.dtd
+source_file = locale/exchangecalendar/en/exchangeSettingsOverlay.dtd
+source_lang = en
+type = DTD
+

--- a/.tx/config
+++ b/.tx/config
@@ -151,6 +151,12 @@ source_file = locale/exchangecalendar/en/rtews.dtd
 source_lang = en
 type = DTD
 
+[exchangecalendar.rtews-properties]
+file_filter = locale/exchangecalendar/<lang>/rtews.properties
+source_file = locale/exchangecalendar/en/rtews.properties
+source_lang = en
+type = MOZILLAPROPERTIES
+
 [exchangecalendar.selectEWSUrl]
 file_filter = locale/exchangecalendar/<lang>/selectEWSUrl.dtd
 source_file = locale/exchangecalendar/en/selectEWSUrl.dtd
@@ -174,4 +180,10 @@ file_filter = locale/exchangecalendar/<lang>/exchangeSettingsOverlay.dtd
 source_file = locale/exchangecalendar/en/exchangeSettingsOverlay.dtd
 source_lang = en
 type = DTD
+
+[exchangecalendar.calExchangeCalendar]
+file_filter = locale/exchangecalendar/<lang>/calExchangeCalendar.properties
+source_file = locale/exchangecalendar/en/calExchangeCalendar.properties
+source_lang = en
+type = MOZILLAPROPERTIES
 

--- a/locale/exchangecalendar/tr/attachments-view.dtd
+++ b/locale/exchangecalendar/tr/attachments-view.dtd
@@ -1,1 +1,1 @@
-<!ENTITY exchWebServie.add.attachment.button.label “Ekler”>
+<!ENTITY exchWebServie.add.attachment.button.label "Ekler">

--- a/locale/exchangecalendar/tr/browseFolder.dtd
+++ b/locale/exchangecalendar/tr/browseFolder.dtd
@@ -1,10 +1,10 @@
-<!ENTITY label.acceptbutton “Seç”>
-<!ENTITY label.cancelbutton “İptal et”>
+<!ENTITY label.acceptbutton "Seç">
+<!ENTITY label.cancelbutton "İptal et">
 
-<!ENTITY browsefolder.title “Klasörlere gözat”>
+<!ENTITY browsefolder.title "Klasörlere gözat">
 
-<!ENTITY treecol.label.foldername “Klasör adı">
-<!ENTITY treecol.label.folderclass “Klasör sınıfı”>
+<!ENTITY treecol.label.foldername "Klasör adı">
+<!ENTITY treecol.label.folderclass "Klasör sınıfı">
 
 
 

--- a/locale/exchangecalendar/tr/calendar-calendars-list.dtd
+++ b/locale/exchangecalendar/tr/calendar-calendars-list.dtd
@@ -1,5 +1,5 @@
-<!ENTITY calendar.context.exchange.convert.label "Exchange 2007/2010 Takvim and Görev Eklentisine Dönüştür”>
-<!ENTITY calendar.context.exchange.properties.label "Exchange (EWS) Özellikleri“>
-<!ENTITY calendar.context.exchange.oof.settings.label “İşyeri Dışında ayarları”>
-<!ENTITY calendar.context.exchange.clone.settings.label “Ayarları yeni takvime kopyala">
-<!ENTITY calendar.context.exchange.delegate.calendar.settings.label “Takvime erişim yetkisi aktar”>
+<!ENTITY calendar.context.exchange.convert.label "Exchange 2007/2010 Takvim and Görev Eklentisine Dönüştür">
+<!ENTITY calendar.context.exchange.properties.label "Exchange (EWS) Özellikleri">
+<!ENTITY calendar.context.exchange.oof.settings.label "İşyeri Dışında ayarları">
+<!ENTITY calendar.context.exchange.clone.settings.label "Ayarları yeni takvime kopyala">
+<!ENTITY calendar.context.exchange.delegate.calendar.settings.label "Takvime erişim yetkisi aktar">

--- a/locale/exchangecalendar/tr/delegate-calendar-dialog.dtd
+++ b/locale/exchangecalendar/tr/delegate-calendar-dialog.dtd
@@ -1,25 +1,25 @@
  
-<!ENTITY  label.delegateCalendar.cancelbutton “İptal Et”>
-<!ENTITY  label.delegateCalendar.userEmail “E-posta”>
-<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl “Toplantı Taleplerini İlet">
+<!ENTITY  label.delegateCalendar.cancelbutton "İptal Et">
+<!ENTITY  label.delegateCalendar.userEmail "E-posta">
+<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl "Toplantı Taleplerini İlet">
 
-<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly “Yalnız Yetkililer">
-<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe “Yetkililer ve Ben”>
-<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo “Yetkililer (bana bildirileri gönder)”>
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly "Yalnız Yetkililer">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe "Yetkililer ve Ben">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo "Yetkililer (bana bildirileri gönder)">
 
-<!ENTITY  label.delegateCalendar.permission “İzinler”>
-<!ENTITY  menuitem.delegateCalendar.permission.author “Yaratıcı”>
-<!ENTITY  menuitem.delegateCalendar.permission.editor “Düzenleyici”>
-<!ENTITY  menuitem.delegateCalendar.permission.reviewer “Gözden Geçirici”>
-<!ENTITY  menuitem.delegateCalendar.permission.none “Yok”>
+<!ENTITY  label.delegateCalendar.permission "İzinler">
+<!ENTITY  menuitem.delegateCalendar.permission.author "Yaratıcı">
+<!ENTITY  menuitem.delegateCalendar.permission.editor "Düzenleyici">
+<!ENTITY  menuitem.delegateCalendar.permission.reviewer "Gözden Geçirici">
+<!ENTITY  menuitem.delegateCalendar.permission.none "Yok">
 
-<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy “Toplantı İletilerinin Kopyalarını Al” >
-<!ENTITY  label.delegateCalendar.permission.viewPrivateItems “Özel Öğeleri Gör” >
+<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy "Toplantı İletilerinin Kopyalarını Al" >
+<!ENTITY  label.delegateCalendar.permission.viewPrivateItems "Özel Öğeleri Gör" >
 
 
-<!ENTITY  delegateCalendar.permission.description.author “Takvim klasöründeki öğeleri oku ya da yarat.” >
+<!ENTITY  delegateCalendar.permission.description.author "Takvim klasöründeki öğeleri oku ya da yarat." >
 <!ENTITY  delegateCalendar.permission.description.editor "Takvim klasöründeki öğeleri oku, yarat ya da değiştir." >
 <!ENTITY  delegateCalendar.permission.description.reviewer "Takvim klasöründeki öğeleri oku." >
-<!ENTITY  delegateCalendar.permission.description.none “Takvim klasörüne erişim in yok." >
+<!ENTITY  delegateCalendar.permission.description.none "Takvim klasörüne erişim in yok." >
 
-<!ENTITY  delegateCalendar.permission.details.label “İzin Detayları: " >
+<!ENTITY  delegateCalendar.permission.details.label "İzin Detayları: " >

--- a/locale/exchangecalendar/tr/ecCalendarCreation.dtd
+++ b/locale/exchangecalendar/tr/ecCalendarCreation.dtd
@@ -1,4 +1,4 @@
-<!ENTITY exchange1.description "Exchange/Windows Active Directory ayarları”>
-<!ENTITY exchange.cache.label “Çevrimdışı önbellek kullan">
+<!ENTITY exchange1.description "Exchange/Windows Active Directory ayarları">
+<!ENTITY exchange.cache.label "Çevrimdışı önbellek kullan">
 
 

--- a/locale/exchangecalendar/tr/exchangeCloneSettings.dtd
+++ b/locale/exchangecalendar/tr/exchangeCloneSettings.dtd
@@ -1,5 +1,5 @@
-<!ENTITY label.acceptbutton “Kaydet”>
-<!ENTITY label.cancelbutton “İptal Et”>
+<!ENTITY label.acceptbutton "Kaydet">
+<!ENTITY label.cancelbutton "İptal Et">
 
-<!ENTITY label.ecExchangeSettings.title “Yeni tarif:”>
+<!ENTITY label.ecExchangeSettings.title "Yeni tarif:">
 

--- a/locale/exchangecalendar/tr/exchangeReminderDialog.dtd
+++ b/locale/exchangecalendar/tr/exchangeReminderDialog.dtd
@@ -1,3 +1,3 @@
-<!ENTITY exchWebService.reminder.relation.origin.label “etkinlik başlamadan önce”>
+<!ENTITY exchWebService.reminder.relation.origin.label "etkinlik başlamadan önce">
 
 

--- a/locale/exchangecalendar/tr/exchangeSettings.dtd
+++ b/locale/exchangecalendar/tr/exchangeSettings.dtd
@@ -1,53 +1,53 @@
-<!ENTITY label.acceptbutton “Kaydet”>
-<!ENTITY label.cancelbutton “İptal et“>
+<!ENTITY label.acceptbutton "Kaydet">
+<!ENTITY label.cancelbutton "İptal et">
 <!ENTITY ecsettings.title "EWS Takvim ve Posta ayarları">
 <!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
-<!ENTITY ecsettings.tab.meetingrequestsettings “Toplantı teklifleri”>
-<!ENTITY ecsettings.tab.calendarfolderproperties “Klasör özellikleri”>
+<!ENTITY ecsettings.tab.meetingrequestsettings "Toplantı teklifleri">
+<!ENTITY ecsettings.tab.calendarfolderproperties "Klasör özellikleri">
 
-<!ENTITY label.ecExchangeSettings.title “Takvim ayarları:">
+<!ENTITY label.ecExchangeSettings.title "Takvim ayarları:">
 
-<!ENTITY label.poll.inbox “Teklifler, değişiklikler ve iptaller için posta kutusunu yokla.">
-<!ENTITY label.poll.inbox.interval "Posta kutusu yoklama sıklığı (saniye):”>
-<!ENTITY label.poll.calendar.interval “Takvim yoklama sıklığı (saniye):">
+<!ENTITY label.poll.inbox "Teklifler, değişiklikler ve iptaller için posta kutusunu yokla.">
+<!ENTITY label.poll.inbox.interval "Posta kutusu yoklama sıklığı (saniye):">
+<!ENTITY label.poll.calendar.interval "Takvim yoklama sıklığı (saniye):">
 
-<!ENTITY label.nomeetingrequestsettings “Toplantı teklifi ayarlayamazsınız, çünkü posta kutunuzun ana takvimini seçmediniz">
+<!ENTITY label.nomeetingrequestsettings "Toplantı teklifi ayarlayamazsınız, çünkü posta kutunuzun ana takvimini seçmediniz">
 
-<!ENTITY label.autorespond.meetingrequest “Yeni davetlere bu automatic yanıtı ver: ">
+<!ENTITY label.autorespond.meetingrequest "Yeni davetlere bu automatic yanıtı ver: ">
 
-<!ENTITY menuitem.label.ec-autorespond-answer.tentative “Belki katılabilirim”>
-<!ENTITY menuitem.label.ec-autorespond-answer.accepted “Katılacağım”>
-<!ENTITY menuitem.label.ec-autorespond-answer.declined “Katılmayacağım”>
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "Belki katılabilirim">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "Katılacağım">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "Katılmayacağım">
 
-<!ENTITY label.autoremove.invitation_cancellation1 “Davetiyeye yanıt vermediyseniz, daveti ve beraberindeki iptal iletisini automatic olarak sil.">
-<!ENTITY label.autoremove.invitation_cancellation2 “İptal iletisi alırsanız, onaylanmış daveti otomatik olarak sil.">
+<!ENTITY label.autoremove.invitation_cancellation1 "Davetiyeye yanıt vermediyseniz, daveti ve beraberindeki iptal iletisini automatic olarak sil.">
+<!ENTITY label.autoremove.invitation_cancellation2 "İptal iletisi alırsanız, onaylanmış daveti otomatik olarak sil.">
 
-<!ENTITY label.autoremove.invitation_response1 “Düzenleyicisi olmadığınız bir toplantının davetine başkaları tarafından gönderilmiş olan yanıtları otomatik olarak sil.">
+<!ENTITY label.autoremove.invitation_response1 "Düzenleyicisi olmadığınız bir toplantının davetine başkaları tarafından gönderilmiş olan yanıtları otomatik olarak sil.">
 
-<!ENTITY label.doautorespond.meetingrequest.message “Yanıtınızda, bir ileti istemek yerine, şu iletiyi gönderiniz.">
-<!ENTITY label.autorespond.meetingrequest.message “İletiniz:”>
+<!ENTITY label.doautorespond.meetingrequest.message "Yanıtınızda, bir ileti istemek yerine, şu iletiyi gönderiniz.">
+<!ENTITY label.autorespond.meetingrequest.message "İletiniz:">
 
-<!ENTITY treecol.label.userid “Kullanıcı Kimliği”>
-<!ENTITY treecol.label.email “Eposta”>
+<!ENTITY treecol.label.userid "Kullanıcı Kimliği">
+<!ENTITY treecol.label.email "Eposta">
 
 
-<!ENTITY ecsettings.tab.offlineCachingproperties “Çevrimdışı Önbellekleme">
+<!ENTITY ecsettings.tab.offlineCachingproperties "Çevrimdışı Önbellekleme">
 
-<!ENTITY label.offlineCacheproperties.cachingStartDate “Önbelleklemeye başlama tarihi:">
+<!ENTITY label.offlineCacheproperties.cachingStartDate "Önbelleklemeye başlama tarihi:">
 <!ENTITY label.offlineCacheproperties.cachingEndDate "Önbelleklemeyi bitirme tarihi:">
-<!ENTITY label.offlineCacheproperties.totalEvents “Önbelleklenen olay sayısı:">
+<!ENTITY label.offlineCacheproperties.totalEvents "Önbelleklenen olay sayısı:">
 <!ENTITY label.offlineCacheproperties.totalTasks "Önbelleklenen görev sayısı:">
 
-<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate “Bugünden önce önbelleklenen ay sayısı:">
+<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate "Bugünden önce önbelleklenen ay sayısı:">
 <!ENTITY label.offlineCacheproperties.monthsBeforeEndDate "Bugünden sonra önbelleklenecek ay sayısı:">
 
-<!ENTITY button.offlineCacheproperties.clearCache “Çevrimdışı önbelleklenmiş verileri temizle">
-<!ENTITY ecsettings.tab.autoprocessingproperties “Otomatik İşlemleme">
+<!ENTITY button.offlineCacheproperties.clearCache "Çevrimdışı önbelleklenmiş verileri temizle">
+<!ENTITY ecsettings.tab.autoprocessingproperties "Otomatik İşlemleme">
 <!ENTITY ecsettings.tab.mailitemsProperties "EWS Ayarları (Posta)">
 
 <!ENTITY label.syncmailitems.interval "Postayla ilişkili öğeleri (etiketler vs.) eşitlemeyi geciktir">
-<!ENTITY label.autoprocessingproperties.deletecancelleditems “İptal edilmiş olayları otomatik olarak sil”>
-<!ENTITY label.autoprocessingproperties.markeventtentative “Olayları otomatikman Kesin değil olarak işaretle ve düzenleyene yanıt gönder">
+<!ENTITY label.autoprocessingproperties.deletecancelleditems "İptal edilmiş olayları otomatik olarak sil">
+<!ENTITY label.autoprocessingproperties.markeventtentative "Olayları otomatikman Kesin değil olarak işaretle ve düzenleyene yanıt gönder">
  
 <!ENTITY label.syncmailitems.active "Postayla ilişkili öğeleri (etiketler vs.) eşitlemeyi aktif tut">
 <!ENTITY label.syncfollowup.deactivtate "Görev takip edilmesini devredışı bırak">

--- a/locale/exchangecalendar/tr/exchangeSettingsOverlay.dtd
+++ b/locale/exchangecalendar/tr/exchangeSettingsOverlay.dtd
@@ -1,53 +1,53 @@
 <!ENTITY ecautodiscover "Exchange’in otomatik keşif işlevini kullan.">
-<!ENTITY ecfolderbase.label “Klasör tabanı:">
-<!ENTITY ecfolderpath.label “Klasör tabanının altındaki yol:">
-<!ENTITY ecfolderidofshare.label “Paylaşılan Klasör Kimliği:”>
-<!ENTITY exchWebServices.SharedFolderID.label “Paylaşılan görünüm adı:">
+<!ENTITY ecfolderbase.label "Klasör tabanı:">
+<!ENTITY ecfolderpath.label "Klasör tabanının altındaki yol:">
+<!ENTITY ecfolderidofshare.label "Paylaşılan Klasör Kimliği:">
+<!ENTITY exchWebServices.SharedFolderID.label "Paylaşılan görünüm adı:">
 
-<!ENTITY menuitem.label.ecfolderbase.calendar “Takvim klasörü">
-<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot “Ortak klasörler">
-<!ENTITY menuitem.label.ecfolderbase.inbox “Posta kutusu klasörü">
-<!ENTITY menuitem.label.ecfolderbase.voicemail “Sesli mesaj klasörü">
-<!ENTITY menuitem.label.ecfolderbase.msgfolderroot “İleti klasörü kökü”>
-<!ENTITY menuitem.label.ecfolderbase.root “Posta kutusunun kökü">
-<!ENTITY menuitem.label.ecfolderbase.tasks “Görevler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.calendar "Takvim klasörü">
+<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot "Ortak klasörler">
+<!ENTITY menuitem.label.ecfolderbase.inbox "Posta kutusu klasörü">
+<!ENTITY menuitem.label.ecfolderbase.voicemail "Sesli mesaj klasörü">
+<!ENTITY menuitem.label.ecfolderbase.msgfolderroot "İleti klasörü kökü">
+<!ENTITY menuitem.label.ecfolderbase.root "Posta kutusunun kökü">
+<!ENTITY menuitem.label.ecfolderbase.tasks "Görevler klasörü">
 
-<!ENTITY menuitem.label.ecfolderbase.contacts “Kişiler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.deleteditems “Silinmiş öğeler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.drafts “Taslaklar klasörü">
-<!ENTITY menuitem.label.ecfolderbase.journal “Günlükleme klasörü">
-<!ENTITY menuitem.label.ecfolderbase.notes "Notlar klasörü”>
-<!ENTITY menuitem.label.ecfolderbase.outbox “Gönderilecek postalar klasörü">
-<!ENTITY menuitem.label.ecfolderbase.sentitems “Gidenler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.junkemail “Gereksiz posta klasörü”>
-<!ENTITY menuitem.label.ecfolderbase.searchfolders “Klasör Arama klasörü">
+<!ENTITY menuitem.label.ecfolderbase.contacts "Kişiler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.deleteditems "Silinmiş öğeler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.drafts "Taslaklar klasörü">
+<!ENTITY menuitem.label.ecfolderbase.journal "Günlükleme klasörü">
+<!ENTITY menuitem.label.ecfolderbase.notes "Notlar klasörü">
+<!ENTITY menuitem.label.ecfolderbase.outbox "Gönderilecek postalar klasörü">
+<!ENTITY menuitem.label.ecfolderbase.sentitems "Gidenler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.junkemail "Gereksiz posta klasörü">
+<!ENTITY menuitem.label.ecfolderbase.searchfolders "Klasör Arama klasörü">
 <!ENTITY menuitem.label.ecfolderbase.version2010 "-- Aşağıdaki seçenekler yalnızca Exchange2010 için geçerlidir --">
-<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot “Çöp kutusu taban klasörü">
-<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions “Çöp kutusu silinenler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion “Çöp kutusu sürümler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges “Çöp kutusu temizleme klasörü">
-<!ENTITY menuitem.label.ecfolderbase.archiveroot “Arşivleme kök klasörü">
-<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot “Arşivdeki iletiler kök klasörü">
-<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems “Arşivdeki silinmişler klasörü">
-<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot “Arşivdeki kurtarılabilirler kök klasörü">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot "Çöp kutusu taban klasörü">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions "Çöp kutusu silinenler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion "Çöp kutusu sürümler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges "Çöp kutusu temizleme klasörü">
+<!ENTITY menuitem.label.ecfolderbase.archiveroot "Arşivleme kök klasörü">
+<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot "Arşivdeki iletiler kök klasörü">
+<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems "Arşivdeki silinmişler klasörü">
+<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot "Arşivdeki kurtarılabilirler kök klasörü">
 <!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsdeletions "Arşivdeki kurtarılabilir silinmişler klasörü">
 <!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsversions "Arşivdeki kurtarılabilir sürümler klasörü">
 <!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemspurges "Arşivdeki kurtarılabilir temizleme klasörü">
 
-<!ENTITY button.label.autodiscovercheck “Otomatik keşif yap">
-<!ENTITY button.label.serverandmailboxcheck “Sunucu ve posta kutusunu denetle">
-<!ENTITY button.label.servercheck “Sunucu ve hesabı denetle">
+<!ENTITY button.label.autodiscovercheck "Otomatik keşif yap">
+<!ENTITY button.label.serverandmailboxcheck "Sunucu ve posta kutusunu denetle">
+<!ENTITY button.label.servercheck "Sunucu ve hesabı denetle">
 
-<!ENTITY ecmailbox.label “Birincil e-posta adresi:">
-<!ENTITY ecmailbox.tooltip “Eğer bir posta kutusu belirtmezseniz, yalnızca ortak klasörlere erişiminiz olacak.">
-<!ENTITY ecwindowsuser.label “Kullanıcı adı:”>
-<!ENTITY ecwindowsdomain.label “Alan adı:”>
-<!ENTITY ecwindowspassword.label “Parola:”>
+<!ENTITY ecmailbox.label "Birincil e-posta adresi:">
+<!ENTITY ecmailbox.tooltip "Eğer bir posta kutusu belirtmezseniz, yalnızca ortak klasörlere erişiminiz olacak.">
+<!ENTITY ecwindowsuser.label "Kullanıcı adı:">
+<!ENTITY ecwindowsdomain.label "Alan adı:">
+<!ENTITY ecwindowspassword.label "Parola:">
 
-<!ENTITY button.label.folderpathcheck “Denetle”>
-<!ENTITY button.label.folderbrowse “Gözat”>
+<!ENTITY button.label.folderpathcheck "Denetle">
+<!ENTITY button.label.folderbrowse "Gözat">
 
-<!ENTITY exchWebServices.UserAvailability.label “Yalnızca posta kutusuna ait takvimin kullanıcı müsaitliği durumu görünür olacak.">
+<!ENTITY exchWebServices.UserAvailability.label "Yalnızca posta kutusuna ait takvimin kullanıcı müsaitliği durumu görünür olacak.">
 
 <!ENTITY exchWebServices.exchtype.label "Exchange Çeşiti">
 <!ENTITY exchWebServices.hostexch.label "Sunucuda Ağırlanan Exchange">

--- a/locale/exchangecalendar/tr/extra-priority.dtd
+++ b/locale/exchangecalendar/tr/extra-priority.dtd
@@ -1,17 +1,17 @@
-<!ENTITY prefwindow.title “İlaveler”>
-<!ENTITY general.label "Genel”> 
-<!ENTITY about.label “Hakkında”> 
+<!ENTITY prefwindow.title "İlaveler">
+<!ENTITY general.label "Genel"> 
+<!ENTITY about.label "Hakkında"> 
  
-<!ENTITY about.description.label “Thunderbird ve Seamonkey uygulamaları için geliştirilmiş özellikler">
-<!ENTITY iconify.label “Yalnız öncelik simgelerini göster"> 
-<!ENTITY shadeHigh.label “Yüksek öncelikli iletiler için arka plan rengi”>
-<!ENTITY shadeLow.label “Alçak öncelikli iletiler için arka plan rengi”>
-<!ENTITY tagImportant.label “Yüksek öncelikli postaları otomatikman Önemli olarak etiketle">
+<!ENTITY about.description.label "Thunderbird ve Seamonkey uygulamaları için geliştirilmiş özellikler">
+<!ENTITY iconify.label "Yalnız öncelik simgelerini göster"> 
+<!ENTITY shadeHigh.label "Yüksek öncelikli iletiler için arka plan rengi">
+<!ENTITY shadeLow.label "Alçak öncelikli iletiler için arka plan rengi">
+<!ENTITY tagImportant.label "Yüksek öncelikli postaları otomatikman Önemli olarak etiketle">
  
-<!ENTITY highestColor.label “En yüksek“>
-<!ENTITY highColor.label “Yüksek”>
-<!ENTITY lowColor.label “Alçak”>
-<!ENTITY lowestColor.label “En alçak“>
+<!ENTITY highestColor.label "En yüksek">
+<!ENTITY highColor.label "Yüksek">
+<!ENTITY lowColor.label "Alçak">
+<!ENTITY lowestColor.label "En alçak">
  
-<!ENTITY prioritycolor  “Özel Renk”>
-<!ENTITY pref.color “Renk Tercihleri:”>
+<!ENTITY prioritycolor  "Özel Renk">
+<!ENTITY pref.color "Renk Tercihleri:">

--- a/locale/exchangecalendar/tr/invitationResponse.dtd
+++ b/locale/exchangecalendar/tr/invitationResponse.dtd
@@ -1,19 +1,19 @@
-<!ENTITY label.acceptbutton “Değişikliği kabul et”>
-<!ENTITY label.cancelbutton “Değişikliği iptal et”>
+<!ENTITY label.acceptbutton "Değişikliği kabul et">
+<!ENTITY label.cancelbutton "Değişikliği iptal et">
 
-<!ENTITY description.invitationResponse “Toplantı yanıtını değiştirdiğini onayla.”>
+<!ENTITY description.invitationResponse "Toplantı yanıtını değiştirdiğini onayla.">
 
-<!ENTITY label.calendarName “Takvim:”>
-<!ENTITY label.itemTitle “Konu:”>
-<!ENTITY label.itemStart “Başlama zamanı:”>
-<!ENTITY label.itemResponse "Yanıtın:”>
-<!ENTITY label.meetingOrganiser "Düzenleyen:”>
+<!ENTITY label.calendarName "Takvim:">
+<!ENTITY label.itemTitle "Konu:">
+<!ENTITY label.itemStart "Başlama zamanı:">
+<!ENTITY label.itemResponse "Yanıtın:">
+<!ENTITY label.meetingOrganiser "Düzenleyen:">
 
-<!ENTITY label.messageReponseBody “Yanıt iletisi:">
+<!ENTITY label.messageReponseBody "Yanıt iletisi:">
 
-<!ENTITY menuitem.label.ec-autorespond-answer.tentative “Katılabilirim”>
-<!ENTITY menuitem.label.ec-autorespond-answer.accepted “Katılacağım”>
-<!ENTITY menuitem.label.ec-autorespond-answer.declined “Katılmayacağım”>
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "Katılabilirim">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "Katılacağım">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "Katılmayacağım">
 
 
 

--- a/locale/exchangecalendar/tr/inviteStyle.dtd
+++ b/locale/exchangecalendar/tr/inviteStyle.dtd
@@ -1,2 +1,2 @@
-<!ENTITY label.inviteCol “Takvim Daveti”>
-<!ENTITY tooltip.inviteCol “Davetiye ile sırala”>
+<!ENTITY label.inviteCol "Takvim Daveti">
+<!ENTITY tooltip.inviteCol "Davetiye ile sırala">

--- a/locale/exchangecalendar/tr/lightning-item-iframe.dtd
+++ b/locale/exchangecalendar/tr/lightning-item-iframe.dtd
@@ -1,6 +1,6 @@
-<!ENTITY exchWebService.owner.label “Sahip:”>
-<!ENTITY exchWebService.totalWork.label "Toplam iş:”>
-<!ENTITY exchWebService.actualWork.label “Gerçekleşen iş:”>
-<!ENTITY exchWebService.mileage.label "Mil olarka uzaklık:”>
-<!ENTITY exchWebService.billingInformation.label “Faturalama bilgileri:”>
-<!ENTITY exchWebService.companies.label “Şirket:”>
+<!ENTITY exchWebService.owner.label "Sahip:">
+<!ENTITY exchWebService.totalWork.label "Toplam iş:">
+<!ENTITY exchWebService.actualWork.label "Gerçekleşen iş:">
+<!ENTITY exchWebService.mileage.label "Mil olarka uzaklık:">
+<!ENTITY exchWebService.billingInformation.label "Faturalama bilgileri:">
+<!ENTITY exchWebService.companies.label "Şirket:">

--- a/locale/exchangecalendar/tr/manageEWSAccounts.dtd
+++ b/locale/exchangecalendar/tr/manageEWSAccounts.dtd
@@ -1,16 +1,16 @@
-<!ENTITY label.acceptbutton “Kapat”>
+<!ENTITY label.acceptbutton "Kapat">
 
 <!ENTITY exchWebService.manageEWSAccounts.newAccount.button "Hesap ekle">
-<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button “Hesap kaldır”>
-<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button “Ayarları kaydet”>
+<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button "Hesap kaldır">
+<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Ayarları kaydet">
 
 <!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Exchange’in otomatik keşif işlevini kullan.">
-<!ENTITY exchWebService.manageEWSAccounts.mailbox.label “Posta kutusu adı:">
-<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label “Kullanıcı adı:”>
-<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label “Alan adı:”>
-<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button “Otomatik keşif yap">
-<!ENTITY exchWebService.manageEWSAccounts.servercheck.button “Sunucu ve hesabı denetle">
-<!ENTITY exchWebService.manageEWSAccounts.name.label “Ad:”>
+<!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Posta kutusu adı:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Kullanıcı adı:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Alan adı:">
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button "Otomatik keşif yap">
+<!ENTITY exchWebService.manageEWSAccounts.servercheck.button "Sunucu ve hesabı denetle">
+<!ENTITY exchWebService.manageEWSAccounts.name.label "Ad:">
 
-<!ENTITY exchWebService.manageEWSAccounts.menuitem "Exchange Web Services Hesapları”>
+<!ENTITY exchWebService.manageEWSAccounts.menuitem "Exchange Web Services Hesapları">
 

--- a/locale/exchangecalendar/tr/messenger_task_delegation.dtd
+++ b/locale/exchangecalendar/tr/messenger_task_delegation.dtd
@@ -1,6 +1,6 @@
-<!ENTITY exchWebService.task.delegation.owner.name “Görev sahibi”>
-<!ENTITY exchWebService.task.delegation.delegator.name “Görev yetkilisi”>
-<!ENTITY exchWebService.task.delegation.accept.button “Kabul et”>
-<!ENTITY exchWebService.task.delegation.decline.button “Reddet”>
-<!ENTITY exchWebService.task.delegation.lastUpdateDate “Son değişikliğin yapıldığı zaman:“>
+<!ENTITY exchWebService.task.delegation.owner.name "Görev sahibi">
+<!ENTITY exchWebService.task.delegation.delegator.name "Görev yetkilisi">
+<!ENTITY exchWebService.task.delegation.accept.button "Kabul et">
+<!ENTITY exchWebService.task.delegation.decline.button "Reddet">
+<!ENTITY exchWebService.task.delegation.lastUpdateDate "Son değişikliğin yapıldığı zaman:">
 

--- a/locale/exchangecalendar/tr/oofSettings.dtd
+++ b/locale/exchangecalendar/tr/oofSettings.dtd
@@ -1,26 +1,26 @@
-<!ENTITY title.oofsettings “İşyeri Dışında ayarları”>
-<!ENTITY label.acceptbutton “Kaydet”>
-<!ENTITY label.cancelbutton “Kapat”>
-<!ENTITY label.oofsettings.title “İşyeri Dışında ayarları bu adres için geçerli:">
+<!ENTITY title.oofsettings "İşyeri Dışında ayarları">
+<!ENTITY label.acceptbutton "Kaydet">
+<!ENTITY label.cancelbutton "Kapat">
+<!ENTITY label.oofsettings.title "İşyeri Dışında ayarları bu adres için geçerli:">
 
-<!ENTITY label.oofstatus "İşyeri Dışında durumu:”>
+<!ENTITY label.oofstatus "İşyeri Dışında durumu:">
 
-<!ENTITY label.externalaudience “Dışarıdaki hangi kişilere İşyeri Dışında iletileri göndermek istiyorsunuz: ">
-<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none “Hiç kimseye”>
-<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known “Yalnızca Kişiler listemde olanlara">
-<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all “Herkese”>
+<!ENTITY label.externalaudience "Dışarıdaki hangi kişilere İşyeri Dışında iletileri göndermek istiyorsunuz: ">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none "Hiç kimseye">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known "Yalnızca Kişiler listemde olanlara">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all "Herkese">
 
-<!ENTITY button.label.internal “İç ileti“>
-<!ENTITY button.label.external “Dış ileti”>
-<!ENTITY label.internalreply “Kendi işimdeki kişilere gönderilecek ileti:">
-<!ENTITY label.externalreply “İşimde olmayanlara gönderilecek ileti:">
+<!ENTITY button.label.internal "İç ileti">
+<!ENTITY button.label.external "Dış ileti">
+<!ENTITY label.internalreply "Kendi işimdeki kişilere gönderilecek ileti:">
+<!ENTITY label.externalreply "İşimde olmayanlara gönderilecek ileti:">
 
-<!ENTITY menuitem.label.exchWebService-oof-status.disabled “Devre dışı“>
-<!ENTITY menuitem.label.exchWebService-oof-status.enabled “Etkin”>
+<!ENTITY menuitem.label.exchWebService-oof-status.disabled "Devre dışı">
+<!ENTITY menuitem.label.exchWebService-oof-status.enabled "Etkin">
 
-<!ENTITY checkbox.label.exchWebService-oof-scheduled “Yalnızca belirtilen zaman  aralığında etkin:">
-<!ENTITY label.hbox-oof-scheduled-startTime “Başlama zamanı:”>
-<!ENTITY label.hbox-oof-scheduled-endTime “Sona erme zamanı:">
+<!ENTITY checkbox.label.exchWebService-oof-scheduled "Yalnızca belirtilen zaman  aralığında etkin:">
+<!ENTITY label.hbox-oof-scheduled-startTime "Başlama zamanı:">
+<!ENTITY label.hbox-oof-scheduled-endTime "Sona erme zamanı:">
 
 
 

--- a/locale/exchangecalendar/tr/preInvitationResponse.dtd
+++ b/locale/exchangecalendar/tr/preInvitationResponse.dtd
@@ -1,14 +1,14 @@
-<!ENTITY dialog.exchWebService.preInvitationResponse.title “Nasıl yanıt vereceksiniz?”>
-<!ENTITY label.acceptbutton “Tamam”>
-<!ENTITY label.cancelbutton “İptal”>
+<!ENTITY dialog.exchWebService.preInvitationResponse.title "Nasıl yanıt vereceksiniz?">
+<!ENTITY label.acceptbutton "Tamam">
+<!ENTITY label.cancelbutton "İptal">
 
-<!ENTITY label.calendarName “Takvim:”>
-<!ENTITY label.itemTitle “Konu:”>
-<!ENTITY label.itemStart “Başlama zamanı:”>
-<!ENTITY label.itemResponse "Yanıtın:”>
-<!ENTITY label.meetingOrganiser “Düzenleyici:”>
+<!ENTITY label.calendarName "Takvim:">
+<!ENTITY label.itemTitle "Konu:">
+<!ENTITY label.itemStart "Başlama zamanı:">
+<!ENTITY label.itemResponse "Yanıtın:">
+<!ENTITY label.meetingOrganiser "Düzenleyici:">
 
-<!ENTITY radio.label.exchWebService.preInvitationResponse.edit “Göndermeden once yanıtını düzenle.”>
-<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow “Yanıtı şimdi gönder.”>
-<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend “Yanıt gönderme.”>
+<!ENTITY radio.label.exchWebService.preInvitationResponse.edit "Göndermeden once yanıtını düzenle.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow "Yanıtı şimdi gönder.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend "Yanıt gönderme.">
 

--- a/locale/exchangecalendar/tr/preferences.dtd
+++ b/locale/exchangecalendar/tr/preferences.dtd
@@ -1,47 +1,47 @@
 <!ENTITY exchangeWebService.paneAccounts.title "Exchange (EWS)">
-<!ENTITY exchangeWebService.paneDebug.title “Günlük kaydı”>
+<!ENTITY exchangeWebService.paneDebug.title "Günlük kaydı">
 
-<!ENTITY exchangeWebService.preferences.tab.accounts “Hesaplar”>
-<!ENTITY exchangeWebService.preferences.tab.debug “Günlük kaydı”>
-<!ENTITY exchangeWebService.preference.debug.file “Günlük dosyasının yeri:”>
-<!ENTITY exchangeWebService.preference.network.debug.caption "Exchange sunucusu ile iletişim:”>
-<!ENTITY exchangeWebService.preference.debug.log.label “Konsola ve/veya bir dosyaya bilgi günlükleme">
-<!ENTITY exchangeWebService.preference.debug.file.button “Tara”>
-<!ENTITY exchangeWebService.preference.network.debug.label "Exchange sunucusu ile iletişim günlükle”>
-<!ENTITY exchangeWebService.preference.network.debuglevel.label1 “Günlükleme seviyesi”>
+<!ENTITY exchangeWebService.preferences.tab.accounts "Hesaplar">
+<!ENTITY exchangeWebService.preferences.tab.debug "Günlük kaydı">
+<!ENTITY exchangeWebService.preference.debug.file "Günlük dosyasının yeri:">
+<!ENTITY exchangeWebService.preference.network.debug.caption "Exchange sunucusu ile iletişim:">
+<!ENTITY exchangeWebService.preference.debug.log.label "Konsola ve/veya bir dosyaya bilgi günlükleme">
+<!ENTITY exchangeWebService.preference.debug.file.button "Tara">
+<!ENTITY exchangeWebService.preference.network.debug.label "Exchange sunucusu ile iletişim günlükle">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label1 "Günlükleme seviyesi">
 <!ENTITY exchangeWebService.preference.network.debuglevel.label2 "1 = Temel bilgiler, 2 = Eksiksiz iletişim">
-<!ENTITY exchangeWebService.preference.authentication.debug.label “İletişimde başarı bilgilerini günlükle (örn. Kimlik doğrulama)”>
-<!ENTITY exchangeWebService.preference.authentication.showpassword.label “Parolayı günlük dosyasında açık metin olarak göster.">
+<!ENTITY exchangeWebService.preference.authentication.debug.label "İletişimde başarı bilgilerini günlükle (örn. Kimlik doğrulama)">
+<!ENTITY exchangeWebService.preference.authentication.showpassword.label "Parolayı günlük dosyasında açık metin olarak göster.">
 
-<!ENTITY exchangeWebService.preference.contacts.debug.caption “Adres defteri/Kişiler:”>
+<!ENTITY exchangeWebService.preference.contacts.debug.caption "Adres defteri/Kişiler:">
 <!ENTITY exchangeWebService.preference.contacts.debuglevel.label1 "Günlükleme seviyesi">
 <!ENTITY exchangeWebService.preference.contacts.debuglevel.label2 "1 = Temel bilgiler, 2 = Eksiksiz iletişim">
 <!ENTITY exchangeWebService.preference.contacts.debug.label "Adres defteri/Kişiler kısmı hakkında bilgileri günlükle">
 
-<!ENTITY exchangeWebService.preferences.titleWin "Exchange (EWS) Seçenekleri”>
+<!ENTITY exchangeWebService.preferences.titleWin "Exchange (EWS) Seçenekleri">
 
-<!ENTITY exchangeWebService.preference.core.debug.caption “Ana sağlayıcı nesnesi:">
-<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = Hiç, 1 = Temel bilgiler, 2 = Ek bilgiler”>
+<!ENTITY exchangeWebService.preference.core.debug.caption "Ana sağlayıcı nesnesi:">
+<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = Hiç, 1 = Temel bilgiler, 2 = Ek bilgiler">
 
-<!ENTITY exchangeWebService.preferences.tab.cache “Önbellekleme”>
-<!ENTITY exchangeWebService.preference.cache.memory.label “En az geçici hafıza önbelleği">
-<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label “Programın başladığı günden kaç gün öncesine kadar indirmeli:">
+<!ENTITY exchangeWebService.preferences.tab.cache "Önbellekleme">
+<!ENTITY exchangeWebService.preference.cache.memory.label "En az geçici hafıza önbelleği">
+<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label "Programın başladığı günden kaç gün öncesine kadar indirmeli:">
 <!ENTITY exchangeWebService.preference.cache.memory.startupAfter.label "Programın başladığı günden kaç gün sonrasına kadar indirmeli:">
 
-<!ENTITY exchangeWebService.preferences.tab.others “Diğerleri”>
-<!ENTITY exchangeWebService.preference.others.prefs.label “İletişim Seçenekleri:">
-<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label “Exchange iletişimleri için en çok yeniden deneme sayısı:">
+<!ENTITY exchangeWebService.preferences.tab.others "Diğerleri">
+<!ENTITY exchangeWebService.preference.others.prefs.label "İletişim Seçenekleri:">
+<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label "Exchange iletişimleri için en çok yeniden deneme sayısı:">
 
-<!ENTITY exchangeWebService.preference.updateFunction.label “Eklenti güncelleme işlevi:">
-<!ENTITY exchangeWebService.preference.checkForUpdates.label “Thunderbird başlarken yen bir eklenti sürümü olup olmadığını otomatik olarak denetle.">
-<!ENTITY exchangeWebService.preference.warnForUpdates.label “Sürümleri kolayca yükleyebilmeniz için, yeni bir sürüm olduğunda bir uyarı göster.">
+<!ENTITY exchangeWebService.preference.updateFunction.label "Eklenti güncelleme işlevi:">
+<!ENTITY exchangeWebService.preference.checkForUpdates.label "Thunderbird başlarken yen bir eklenti sürümü olup olmadığını otomatik olarak denetle.">
+<!ENTITY exchangeWebService.preference.warnForUpdates.label "Sürümleri kolayca yükleyebilmeniz için, yeni bir sürüm olduğunda bir uyarı göster.">
 <!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Beta, rc, vs. gibi yeni bir ön sürüm mevcut olduğunda bir uyarı göster."> 
 
-<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption “YükDengeleyici:”>
+<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "YükDengeleyici:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "YükDengeleyici:">
-<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label “Exchange sunucuna aynı anda gönderilebilecek en yüksek istek sayısı:">
-<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label “Exchange sunucuna gönderilen istekler arasındaki en kısa bekleme süresi:">
-<!ENTITY exchangeWebService.preference.userAgent.label "HTTP kullanıcı aracısı:”>
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Exchange sunucuna aynı anda gönderilebilecek en yüksek istek sayısı:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Exchange sunucuna gönderilen istekler arasındaki en kısa bekleme süresi:">
+<!ENTITY exchangeWebService.preference.userAgent.label "HTTP kullanıcı aracısı:">
 
 
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Tercihleri:">

--- a/locale/exchangecalendar/tr/selectEWSUrl.dtd
+++ b/locale/exchangecalendar/tr/selectEWSUrl.dtd
@@ -1,8 +1,8 @@
-<!ENTITY label.acceptbutton "Seç”>
-<!ENTITY label.cancelbutton “İptal et”>
+<!ENTITY label.acceptbutton "Seç">
+<!ENTITY label.cancelbutton "İptal et">
 
-<!ENTITY description.selectews “Listeden, yerinize uygun bir EWS sunucusu seçiniz.”>
-<!ENTITY label.selectews "EWS sunucusu listesi:”>
+<!ENTITY description.selectews "Listeden, yerinize uygun bir EWS sunucusu seçiniz.">
+<!ENTITY label.selectews "EWS sunucusu listesi:">
 
 
 

--- a/locale/exchangecalendar/tr/sendUpdateTo.dtd
+++ b/locale/exchangecalendar/tr/sendUpdateTo.dtd
@@ -1,8 +1,8 @@
-<!ENTITY title.sendupdateto “Bu güncelleştirmeyi kime göndermek istiyorsun?">
-<!ENTITY label.acceptbutton “Gerçekleştir”>
-<!ENTITY label.cancelbutton “İptal et”>
-<!ENTITY label.calendaritem.title “Toplantı için güncelleştirme gönder:”>
+<!ENTITY title.sendupdateto "Bu güncelleştirmeyi kime göndermek istiyorsun?">
+<!ENTITY label.acceptbutton "Gerçekleştir">
+<!ENTITY label.cancelbutton "İptal et">
+<!ENTITY label.calendaritem.title "Toplantı için güncelleştirme gönder:">
 
-<!ENTITY radio.label.sendtonone “Kimseye gönderme.”>
-<!ENTITY radio.label.sendtoall “Davetli olan herkese gönder.”>
-<!ENTITY radio.label.sendtochanged “Yalnızca eklenmiş ya da çıkarılmış olan kişilere gönder.”>
+<!ENTITY radio.label.sendtonone "Kimseye gönderme.">
+<!ENTITY radio.label.sendtoall "Davetli olan herkese gönder.">
+<!ENTITY radio.label.sendtochanged "Yalnızca eklenmiş ya da çıkarılmış olan kişilere gönder.">

--- a/locale/exchangecalendar/tr/sharedCalendarParser.dtd
+++ b/locale/exchangecalendar/tr/sharedCalendarParser.dtd
@@ -1,3 +1,3 @@
-<!ENTITY exchWebService_vbox_label “Bir Exchange paylaşma daveti tespit edildi”>
-<!ENTITY exchWebService_button_label_add_calendar “Takvim ekle”>
+<!ENTITY exchWebService_vbox_label "Bir Exchange paylaşma daveti tespit edildi">
+<!ENTITY exchWebService_button_label_add_calendar "Takvim ekle">
 


### PR DESCRIPTION
Finally this part init and configures the Transifex project inside Github.

The Transifex client is simply configured with file `.tx/configure`.

This file has been semi-autogenerated with commands `find` (to look for files to translate) and `tx` (the transifex client).

Update: add review parts:
* Stuff to fix double quotes: https://github.com/ExchangeCalendar/exchangecalendar/pull/89/commits/68682df80c603807bb4aa9410903a068fbb8837c 
* Stuff to configure Transifex: https://github.com/ExchangeCalendar/exchangecalendar/pull/89/files/68682df80c603807bb4aa9410903a068fbb8837c..d2a649c164da0cd784a4f5e1e265433c39f347dd