### PR TITLE
l10n: fix last commit about Transifex and set en as default locale

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -43,17 +43,19 @@ overlay chrome://messenger/content/messenger.xul  chrome://exchangecalendar/cont
 overlay chrome://messenger/content/folderProps.xul  chrome://exchangecalendar/content/folderPropsOverlay.xul
 overlay chrome://messenger/content/messenger.xul chrome://exchangecalendar/content/rtews-overlay.xul
 
-locale exchangecalendar nl locale/exchangecalendar/nl/
+
 locale exchangecalendar en locale/exchangecalendar/en/
-locale exchangecalendar en_US locale/exchangecalendar/en_US/
-locale exchangecalendar fr_FR locale/exchangecalendar/fr_FR/
+
+locale exchangecalendar nl locale/exchangecalendar/nl/
+locale exchangecalendar en-US locale/exchangecalendar/en_US/
+locale exchangecalendar fr-FR locale/exchangecalendar/fr_FR/
 locale exchangecalendar de locale/exchangecalendar/de/
-locale exchangecalendar ja_JP locale/exchangecalendar/ja_JP/
+locale exchangecalendar ja-JP locale/exchangecalendar/ja_JP/
 locale exchangecalendar sv locale/exchangecalendar/sv/
 locale exchangecalendar ru locale/exchangecalendar/ru/
-locale exchangecalendar it_IT locale/exchangecalendar/it_IT/
+locale exchangecalendar it-IT locale/exchangecalendar/it_IT/
 locale exchangecalendar tr locale/exchangecalendar/tr/
-locale exchangecalendar cs_CZ locale/exchangecalendar/cs_CZ/
+locale exchangecalendar cs-CZ locale/exchangecalendar/cs_CZ/
 
 manifest interfaces/exchangeCalendar/mivExchangeCalendar.manifest
 

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -46,16 +46,16 @@ overlay chrome://messenger/content/messenger.xul chrome://exchangecalendar/conte
 
 locale exchangecalendar en locale/exchangecalendar/en/
 
-locale exchangecalendar nl locale/exchangecalendar/nl/
+locale exchangecalendar cs-CZ locale/exchangecalendar/cs_CZ/
+locale exchangecalendar de locale/exchangecalendar/de/
 locale exchangecalendar en-US locale/exchangecalendar/en_US/
 locale exchangecalendar fr-FR locale/exchangecalendar/fr_FR/
-locale exchangecalendar de locale/exchangecalendar/de/
-locale exchangecalendar ja-JP locale/exchangecalendar/ja_JP/
-locale exchangecalendar sv locale/exchangecalendar/sv/
-locale exchangecalendar ru locale/exchangecalendar/ru/
 locale exchangecalendar it-IT locale/exchangecalendar/it_IT/
+locale exchangecalendar ja-JP locale/exchangecalendar/ja_JP/
+locale exchangecalendar nl locale/exchangecalendar/nl/
+locale exchangecalendar ru locale/exchangecalendar/ru/
+locale exchangecalendar sv locale/exchangecalendar/sv/
 locale exchangecalendar tr locale/exchangecalendar/tr/
-locale exchangecalendar cs-CZ locale/exchangecalendar/cs_CZ/
 
 manifest interfaces/exchangeCalendar/mivExchangeCalendar.manifest
 

--- a/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
+++ b/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
@@ -12,10 +12,10 @@ manifest exchangeAbRootDirectory/exchangeAbRootDirectory.manifest
 
 locale exchangecontacts en    locale/exchangecontacts/en/
 
-locale exchangecontacts nl    locale/exchangecontacts/nl/
+locale exchangecontacts de    locale/exchangecontacts/de/
 locale exchangecontacts en-US locale/exchangecontacts/en_US/
 locale exchangecontacts fr-FR locale/exchangecontacts/fr_FR/
-locale exchangecontacts de    locale/exchangecontacts/de/
 locale exchangecontacts ja-JP locale/exchangecontacts/ja_JP/
-locale exchangecontacts sv    locale/exchangecontacts/sv/
+locale exchangecontacts nl    locale/exchangecontacts/nl/
 locale exchangecontacts ru    locale/exchangecontacts/ru/
+locale exchangecontacts sv    locale/exchangecontacts/sv/

--- a/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
+++ b/interfaces/exchangeAddressBook/exchangeAddressBook.manifest
@@ -10,8 +10,9 @@ manifest exchangeAbDistListDirectory/exchangeAbDistListDirectory.manifest
 manifest exchangeAbFolderDirectory/exchangeAbFolderDirectory.manifest
 manifest exchangeAbRootDirectory/exchangeAbRootDirectory.manifest
 
-locale exchangecontacts nl    locale/exchangecontacts/nl/
 locale exchangecontacts en    locale/exchangecontacts/en/
+
+locale exchangecontacts nl    locale/exchangecontacts/nl/
 locale exchangecontacts en-US locale/exchangecontacts/en_US/
 locale exchangecontacts fr-FR locale/exchangecontacts/fr_FR/
 locale exchangecontacts de    locale/exchangecontacts/de/


### PR DESCRIPTION
Last commit for Transifex has been made too fast and it has broken some localisations like fr-FR by applying "find and replace".

To set the default language, I've setted the `en` locale first, as my broken `fr-FR` build had `nl` localisations.