### PR TITLE
Update beautify targets to add newline at end of Javascript files and to not wrap install.rdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,17 @@ dev: beautify build
 beautify: beautify-xml beautify-js
 
 beautify-xml:
-	find \( -name "*.xml" -o -name "*.rdf" -o -name "*.xul" \) -exec \
+	find \( -name "*.xml" -o -name "*.xul" \) -exec \
 		tidy --input-xml yes --indent auto --indent-spaces 4 --indent-attributes yes \
 		--preserve-entities yes --quote-ampersand no --quote-nbsp no --output-xml yes \
 		--strict-tags-attributes no --write-back yes \
-		 {} \;
+		{} \;
+	# For rdf files, we don't want to wrap lines to keep em:description on one line.
+	find -name "*.rdf" -exec \
+		tidy --input-xml yes --indent auto --indent-spaces 4 --indent-attributes yes \
+		--preserve-entities yes --quote-ampersand no --quote-nbsp no --output-xml yes \
+		--strict-tags-attributes no --write-back yes --wrap 0 \
+		{} \;
 beautify-js:
 	find -name "*.js" -exec \
 		js-beautify --indent-size=4 --indent-char=' ' --jslint-happy \

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,5 @@ beautify-js:
 	find -name "*.js" -exec \
 		js-beautify --indent-size=4 --indent-char=' ' --jslint-happy \
 		--operator-position after-newline --brace-style end-expand --replace \
+		--end-with-newline \
 		{} \;

--- a/install.rdf
+++ b/install.rdf
@@ -7,8 +7,7 @@
         <em:targetApplication>
             <Description>
                 <!-- Thunderbird -->
-                <em:id>
-                {3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
+                <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
                 <em:minVersion>52.0.0</em:minVersion>
                 <em:maxVersion>52.*.*</em:maxVersion>
             </Description>
@@ -16,18 +15,15 @@
         <em:targetApplication>
             <Description>
                 <!-- Seamonkey -->
-                <em:id>
-                {92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+                <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
                 <em:minVersion>2.49.*</em:minVersion>
                 <em:maxVersion>2.49.*</em:maxVersion>
             </Description>
         </em:targetApplication>
         <em:unpack>true</em:unpack>
         <em:name>Exchange Calendar</em:name>
-        <em:homepageURL>
-        https://github.com/ExchangeCalendar/exchangecalendar</em:homepageURL>
-        <em:iconURL>
-        chrome://exchangecalendar-common/skin/images/lightningexchangecalendar.png</em:iconURL>
+        <em:homepageURL>https://github.com/ExchangeCalendar/exchangecalendar</em:homepageURL>
+        <em:iconURL>chrome://exchangecalendar-common/skin/images/lightningexchangecalendar.png</em:iconURL>
         <em:creator>Michel Verbraak</em:creator>
         <em:developer>ExchangeCalendar community</em:developer>
         <em:translator>Michel Verbraak (nl)</em:translator>
@@ -43,18 +39,14 @@
             <Description>
                 <em:locale>en</em:locale>
                 <em:name>Exchange Calendar</em:name>
-                <em:description>Allows you to sync calendars,
-                tasks, and contacts with Microsoft
-                Exchange.</em:description>
+                <em:description>Allows you to sync calendars, tasks, and contacts with Microsoft Exchange.</em:description>
             </Description>
         </em:localized>
         <em:localized>
             <Description>
                 <em:locale>fr</em:locale>
                 <em:name>Exchange Calendar</em:name>
-                <em:description>Vous permet de synchroniser les
-                calendriers, tâches et contactes avec Microsoft
-                Exchange.</em:description>
+                <em:description>Vous permet de synchroniser les calendriers, tâches et contactes avec Microsoft Exchange.</em:description>
             </Description>
         </em:localized>
     </Description>


### PR DESCRIPTION
This patch updates the beautify-javascript Makefile target to add new line at end of files automatically.

The beautify-xml Makefile target is also updated to not wrap by default RDF files.
That's especially needed for the `install.rdf` file which needs to keep the description on one line as Thunderbird displays all spaces and new lines in add-on description.