### PR TITLE
Disable debug preferences

### DIFF
--- a/chrome/content/otherPreferences.xul
+++ b/chrome/content/otherPreferences.xul
@@ -77,6 +77,9 @@
             <preference id="extensions.1st-setup.others.userAgent"
                         name="extensions.1st-setup.others.userAgent"
                         type="unichar" />
+            <preference id="extensions.1st-setup.others.globalsearch"
+                        name="mailnews.database.global.indexer.enabled"
+                        type="bool" />
             <preference id="extensions.1st-setup.others.ntlmv1"
                         name="network.auth.force-generic-ntlm-v1"
                         type="bool" />
@@ -157,6 +160,15 @@
                             oncommand="tmpOtherPreferences.ieDefault();"
                             flex="1" />
                 </hbox>
+            </vbox>
+        </groupbox>
+        <groupbox id="exchangeWebService_others_prefs_groupbox5">
+            <caption label="&exchangeWebService.preference.globalsearch.caption;" />
+            <vbox>
+                <checkbox id="globalsearch"
+                          preference="extensions.1st-setup.others.globalsearch"
+                          label="&exchangeWebService.preference.globalsearch.label;" />
+                <label>&exchangeWebService.preference.globalsearch.explain;</label>
             </vbox>
         </groupbox>
         <groupbox id="exchangeWebService_others_prefs_groupbox4">

--- a/defaults/preferences/debug.js
+++ b/defaults/preferences/debug.js
@@ -1,4 +1,5 @@
 /* debugging prefs */
+/*
 pref("browser.dom.window.dump.enabled", true);
 pref("javascript.options.showInConsole", true);
 pref("javascript.options.strict", true);
@@ -16,3 +17,4 @@ pref("extensions.extras.ShadeLow", false);
 pref("calendar.timezone.local.auto", true);
 pref("extensions.1st-setup.others.warnAboutPrereleaseVersion", true);
 user_pref("mailnews.database.global.indexer.enabled", true);
+*/

--- a/locale/exchangecalendar/en/preferences.dtd
+++ b/locale/exchangecalendar/en/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/locale/exchangecalendar/en_US/preferences.dtd
+++ b/locale/exchangecalendar/en_US/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">


### PR DESCRIPTION
It disable all preferences modification made by the default/preferences/debug.pref.js.

I didn't remove the file directly, because I wanted to keep information about which configs orignal others have found interesting to modify.

As suggested in the Ericsson/exchangecalendar#506 pull request, I've added a preference choice to enable/disable the Thunderbird global index:

![ExchangeCalendar other pref screenshot](https://cloud.adorsaz.ch/index.php/s/IZtfSuGrcSE8Kpv/download)

I've looked at the Thunderbird preference to add an information directly in the "Thunderbird Prefrences dialog > Advanced > Advanced Configuration". But I failed to add the information there, because I wasn't able to do all the path through ids to add an element after the global indexer checkbox.

PS: Please note you have to try this fix in a en-US Thunderbird installation, because we need to create labels in all languages before it could work. So:
* test this patch, you'll need to change the locale with an extension, like "Simple Locale Switcher"
* Before releasing, we'll need to push new strings to Transifex and get back them into all languages.