### PR TITLE
Fix builds on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /install.rdf
+/exchangecalendar-v*.xpi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/install.rdf

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ version = $(shell cat VERSION)
 excludefromxpi = .git/\* .gitignore \*/.gitignore .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION install.rdf.template
 releasebranch = ec-4.0
 update = disable
+xpi = exchangecalendar-v$(version).xpi
 
 .PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js defaults/preferences/update.js
 
 # Default target is build package
 build: install.rdf defaults/preferences/update.js
 	# Finally, create the xpi file
-	zip -r exchangecalendar-v"$(version)".xpi -x $(excludefromxpi) -- . 
+	zip -r $(xpi) -x $(excludefromxpi) -- . 
 
 install.rdf: install.rdf.template
 	sed 's/@VERSION@/$(version)/g' install.rdf.template > install.rdf

--- a/Makefile
+++ b/Makefile
@@ -50,19 +50,19 @@ dev: beautify build
 beautify: beautify-xml beautify-js
 
 beautify-xml:
-	find \( -name "*.xml" -o -name "*.xul" \) -exec \
+	find . \( -name "*.xml" -o -name "*.xul" \) -exec \
 		tidy --input-xml yes --indent auto --indent-spaces 4 --indent-attributes yes \
 		--preserve-entities yes --quote-ampersand no --quote-nbsp no --output-xml yes \
 		--strict-tags-attributes no --write-back yes \
 		{} \;
 	# For rdf files, we don't want to wrap lines to keep em:description on one line.
-	find \( -name "*.rdf" -o -name "*.rdf.template" \) -exec \
+	find . \( -name "*.rdf" -o -name "*.rdf.template" \) -exec \
 		tidy --input-xml yes --indent auto --indent-spaces 4 --indent-attributes yes \
 		--preserve-entities yes --quote-ampersand no --quote-nbsp no --output-xml yes \
 		--strict-tags-attributes no --write-back yes --wrap 0 \
 		{} \;
 beautify-js:
-	find -name "*.js" -exec \
+	find . -name "*.js" -exec \
 		js-beautify --indent-size=4 --indent-char=' ' --jslint-happy \
 		--operator-position after-newline --brace-style end-expand --replace \
 		--end-with-newline \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ beautify-xml:
 		--strict-tags-attributes no --write-back yes \
 		{} \;
 	# For rdf files, we don't want to wrap lines to keep em:description on one line.
-	find -name "*.rdf" -exec \
+	find \( -name "*.rdf" -o -name "*.rdf.template" \) -exec \
 		tidy --input-xml yes --indent auto --indent-spaces 4 --indent-attributes yes \
 		--preserve-entities yes --quote-ampersand no --quote-nbsp no --output-xml yes \
 		--strict-tags-attributes no --write-back yes --wrap 0 \

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 version = $(shell cat VERSION)
-excludefromxpi = .git/\* .gitignore .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION install.rdf.template
+excludefromxpi = .git/\* .gitignore \*/.gitignore .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION install.rdf.template
 releasebranch = ec-4.0
+update = disable
 
-.PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js
+.PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js defaults/preferences/update.js
 
 # Default target is build package
-build: install.rdf
-	# Disable automatic updates of the extension
-	cat defaults/preferences/update_disable.txt > defaults/preferences/update.js
+build: install.rdf defaults/preferences/update.js
 	# Finally, create the xpi file
 	zip -r exchangecalendar-v"$(version)".xpi -x $(excludefromxpi) -- . 
 
 install.rdf: install.rdf.template
 	sed 's/@VERSION@/$(version)/g' install.rdf.template > install.rdf
+
+defaults/preferences/update.js:
+	cp defaults/preferences/update_$(update).txt defaults/preferences/update.js
 
 # Target to publish a new release:
 release: l10n-auto-commit build

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ xpi = exchangecalendar-v$(version).xpi
 build: $(xpi)
 
 $(xpi): install.rdf defaults/preferences/update.js
-	zip -r $(xpi) -x $(excludefromxpi) -- . 
+	zip -r $@ -x $(excludefromxpi) -- .
 
 install.rdf: install.rdf.template
-	sed 's/@VERSION@/$(version)/g' install.rdf.template > install.rdf
+	sed 's/@VERSION@/$(version)/g' $< > $@
 
 defaults/preferences/update.js:
-	cp defaults/preferences/update_$(update).txt defaults/preferences/update.js
+	cp defaults/preferences/update_$(update).txt $@
 
 # Target to publish a new release:
 release: l10n-auto-commit build

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 version = $(shell cat VERSION)
-excludefromxpi = .git/\* .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION
+excludefromxpi = .git/\* .gitignore .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION install.rdf.template
 releasebranch = ec-4.0
 
 # Default target is build package
-build:
-	# Update version number inside install.rdf file from VERSION file
-	sed -i 's/\(\s*\)<em:version>[^<]*\?<\/em:version>/\1<em:version>$(version)<\/em:version>/' install.rdf
+build: install.rdf
 	# Disable automatic updates of the extension
 	cat defaults/preferences/update_disable.txt > defaults/preferences/update.js
 	# Finally, create the xpi file
 	zip -r exchangecalendar-v"$(version)".xpi -x $(excludefromxpi) -- . 
+
+install.rdf: install.rdf.template
+	sed 's/@VERSION@/$(version)/g' install.rdf.template > install.rdf
 
 # Target to publish a new release:
 release: l10n-auto-commit build

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ defaults/preferences/update.js:
 
 # Target to publish a new release:
 release: l10n-auto-commit build
-	git add -- install.rdf
-	git commit -m "releases v$(version)"
 	git tag "v$(version)"
 	@echo 'Translations updated, build done, tag added.'
 	@echo 'Now, if the release is well done, please run one "git push" to publish code and one "git push v$(version)" to publish the new tag.'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ version = $(shell cat VERSION)
 excludefromxpi = .git/\* .gitignore .tx/\* \*.xpi \*.sh update\*.txt Makefile VERSION install.rdf.template
 releasebranch = ec-4.0
 
+.PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js
+
 # Default target is build package
 build: install.rdf
 	# Disable automatic updates of the extension

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@ releasebranch = ec-4.0
 update = disable
 xpi = exchangecalendar-v$(version).xpi
 
-.PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js defaults/preferences/update.js
+.PHONY: build release l10n-get l10n-auto-commit l10n-push dev beautify beautify-xml beautify-js defaults/preferences/update.js $(xpi)
 
 # Default target is build package
-build: install.rdf defaults/preferences/update.js
-	# Finally, create the xpi file
+build: $(xpi)
+
+$(xpi): install.rdf defaults/preferences/update.js
 	zip -r $(xpi) -x $(excludefromxpi) -- . 
 
 install.rdf: install.rdf.template

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ xpi = exchangecalendar-v$(version).xpi
 build: $(xpi)
 
 $(xpi): install.rdf defaults/preferences/update.js
+	rm -f $@
 	zip -r $@ -x $(excludefromxpi) -- .
 
 install.rdf: install.rdf.template

--- a/defaults/preferences/.gitignore
+++ b/defaults/preferences/.gitignore
@@ -1,0 +1,1 @@
+/update.js

--- a/defaults/preferences/update.js
+++ b/defaults/preferences/update.js
@@ -1,1 +1,0 @@
-user_pref("extensions.1st-setup.others.updateRequired", true);

--- a/install.rdf.template
+++ b/install.rdf.template
@@ -3,7 +3,7 @@
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
     <Description about="urn:mozilla:install-manifest">
         <em:id>exchangecalendar@extensions.1st-setup.nl</em:id>
-        <em:version>4.0.0-beta5</em:version>
+        <em:version>@VERSION@</em:version>
         <em:targetApplication>
             <Description>
                 <!-- Thunderbird -->


### PR DESCRIPTION
Address a few platform differences such as `sed -i` option and omitting the current directory if it is the only path argument to `find`.

Also, make builds repeatable and not touch source-controlled files, and .gitignore build artifacts.