### PR TITLE
Release 4 beta5: update changelog and translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,34 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [4.0.0-beta5] - 2017-**-**
+## [4.0.0-beta5] - 2018-01-28
 ### Added
+- Code beautifiers are available for JavaScript, XML, XUL and RDF files
+- Translations are now managed with the Transifex tools.
+  You can participate with our [Transifex project](https://www.transifex.com/exchangecalendar/exchangecalendar/)
+- New locales: cs-CZ, pl, sk
+- Thunderbird Global Search preferences to explain that emailtag need them and won't work if disabled.
 
 ### Changed
-- Use Makefile instead of custom build shell
+- Use Makefile instead of custom build shell (#98)
 - Update install.rdf, README with new community
 - Builds now will disable automatic update checker to avoid issue with new forks
+- XML requests sent to Exchange servers now set "utf-8" for Content-Type HTTP header.
+- Logs now redirects to ExchangeCalendar Github community (#92)
+- Code tree has been structured to distinguish parts of the module (#80)
+  Current parts are now: addressbook, calendar, common and emailtag
+  Namespaces were updated too to reflect the new code structure.
 
 ### Fixed
+- Compatibilty with Lightning 5.4.2 and the new option to edit events and tasks from tabs (#60)
+- Some events were hidden from month view due to TimeZone errors (#67)
+- Hide password in logs if requested (#100)
+- Hide password shown in dialog boxes (#103)
+
+### Removed
+- `email` root directory contained only empty codes.
+- debug preferences were always enabled, they are now removed (#133)
+  It was disabling cache and forced the Thunderbird Global Search Indexer to be enabled.
 
 ## [4.0.0-beta4] - 2017-07-03
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ l10n-auto-commit: l10n-get
 # Send new texts to translate to Transifex
 l10n-push:
 	git checkout $(releasebranch)
-	tx push
+	tx push -s
 
 # Target to beautify and build your code while developing it
 dev: beautify build

--- a/addressbook/exchangeAddressBook.manifest
+++ b/addressbook/exchangeAddressBook.manifest
@@ -16,10 +16,15 @@ manifest interface/exchangeAutoCompleteResult/mivExchangeAutoCompleteResult.mani
 
 locale exchangecontacts en    locale/en/
 
+locale exchangecontacts cs-CZ locale/cs_CZ/
 locale exchangecontacts de    locale/de/
 locale exchangecontacts en-US locale/en_US/
 locale exchangecontacts fr-FR locale/fr_FR/
+locale exchangecontacts it-IT locale/it_IT/
 locale exchangecontacts ja-JP locale/ja_JP/
 locale exchangecontacts nl    locale/nl/
+locale exchangecontacts pl    locale/pl/
 locale exchangecontacts ru    locale/ru/
+locale exchangecontacts sk    locale/sk/
 locale exchangecontacts sv    locale/sv/
+locale exchangecontacts tr    locale/tr/

--- a/addressbook/locale/cs_CZ/ExchangeContacts.properties
+++ b/addressbook/locale/cs_CZ/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage=„%4$S“: Obdrženy aktualizace kontaktů z EWS serveru (nové: %1$S, změněné: %2$S, odebrané: %3$S).
+promtpDeleteDirectoryTitle=Odebrat složku s kontakty?
+promptDeleteDirectoryText=Opravdu chcete odebrat „%1$S“?

--- a/addressbook/locale/cs_CZ/ExchangeDistLists.properties
+++ b/addressbook/locale/cs_CZ/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage=„%4$S“: Obdrženy aktualizace distribučních seznamů z EWS serveru (nové: %1$S, změněné: %2$S, odebrané: %3$S).
+promtpDeleteDirectoryTitle=Odebrat složku s kontakty?
+promptDeleteDirectoryText=Opravdu chcete odebrat „%1$S“?

--- a/addressbook/locale/cs_CZ/addressbookOverlay.dtd
+++ b/addressbook/locale/cs_CZ/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Přidat složku s kontakty z Exchange">
+<!ENTITY toolbar.button.tooltip.addaccount "Toto přidá novou složku s kontakty z Exchange">
+
+<!ENTITY toolbar.button.label.deleteaccount "Odebrat složku s kontakty z Exchange">
+<!ENTITY toolbar.button.tooltip.deleteaccount "Toto odebere existující složku s kontakty z Exchange">
+
+<!ENTITY deleteExchangeCmd.label "Odebrat složku s kontakty z Exchange">
+
+

--- a/addressbook/locale/cs_CZ/exchangeContactSettings.dtd
+++ b/addressbook/locale/cs_CZ/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Uložit">
+<!ENTITY label.cancelbutton "Storno">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Žádost o schůzku">
+
+<!ENTITY label.ecExchangeSettings.title "Název v seznamu:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Interval obnovování (v sekundách):">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Zahrnout globální adresář kontaktů do výsledků vyhledávání.">
+

--- a/addressbook/locale/it_IT/ExchangeContacts.properties
+++ b/addressbook/locale/it_IT/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received contact update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/it_IT/ExchangeDistLists.properties
+++ b/addressbook/locale/it_IT/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received distribution list update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/it_IT/addressbookOverlay.dtd
+++ b/addressbook/locale/it_IT/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Add Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.addaccount "This will add a new Exchange contact folder">
+
+<!ENTITY toolbar.button.label.deleteaccount "Remove Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.deleteaccount "This will remove an existing Exchange contact folder">
+
+<!ENTITY deleteExchangeCmd.label "Remove Exchange contact folder">
+
+

--- a/addressbook/locale/it_IT/exchangeContactSettings.dtd
+++ b/addressbook/locale/it_IT/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting request">
+
+<!ENTITY label.ecExchangeSettings.title "Name in list:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Refresh interval in seconds:">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Add global address list to search results.">
+

--- a/addressbook/locale/pl/ExchangeContacts.properties
+++ b/addressbook/locale/pl/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received contact update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/pl/ExchangeDistLists.properties
+++ b/addressbook/locale/pl/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received distribution list update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/pl/addressbookOverlay.dtd
+++ b/addressbook/locale/pl/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Add Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.addaccount "This will add a new Exchange contact folder">
+
+<!ENTITY toolbar.button.label.deleteaccount "Remove Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.deleteaccount "This will remove an existing Exchange contact folder">
+
+<!ENTITY deleteExchangeCmd.label "Remove Exchange contact folder">
+
+

--- a/addressbook/locale/pl/exchangeContactSettings.dtd
+++ b/addressbook/locale/pl/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting request">
+
+<!ENTITY label.ecExchangeSettings.title "Name in list:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Refresh interval in seconds:">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Add global address list to search results.">
+

--- a/addressbook/locale/sk/ExchangeContacts.properties
+++ b/addressbook/locale/sk/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received contact update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/sk/ExchangeDistLists.properties
+++ b/addressbook/locale/sk/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": Received distribution list update(s) from EWS server (New: %1$S, Changed: %2$S, Removed: %3$S).
+promtpDeleteDirectoryTitle=Remove contacts folder?
+promptDeleteDirectoryText=Are you really sure you want to remove "%1$S"?

--- a/addressbook/locale/sk/addressbookOverlay.dtd
+++ b/addressbook/locale/sk/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Add Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.addaccount "This will add a new Exchange contact folder">
+
+<!ENTITY toolbar.button.label.deleteaccount "Remove Exchange contact folder">
+<!ENTITY toolbar.button.tooltip.deleteaccount "This will remove an existing Exchange contact folder">
+
+<!ENTITY deleteExchangeCmd.label "Remove Exchange contact folder">
+
+

--- a/addressbook/locale/sk/exchangeContactSettings.dtd
+++ b/addressbook/locale/sk/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting request">
+
+<!ENTITY label.ecExchangeSettings.title "Name in list:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Refresh interval in seconds:">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Add global address list to search results.">
+

--- a/addressbook/locale/tr/ExchangeContacts.properties
+++ b/addressbook/locale/tr/ExchangeContacts.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": EWS sunucusundan kişilerin güncellemesi alındı (Yeni: %1$S, Değiştirilmiş: %2$S, Kaldırılmış: %3$S).
+promtpDeleteDirectoryTitle=Kişiler klasörü kaldırılıyor?
+promptDeleteDirectoryText="%1$S" klasörünü kaldırmak istediğinize emin misiniz?

--- a/addressbook/locale/tr/ExchangeDistLists.properties
+++ b/addressbook/locale/tr/ExchangeDistLists.properties
@@ -1,0 +1,3 @@
+syncFolderEventMessage="%4$S": EWS sunucusundan dağıtım listesi güncellemesi alındı (Yeni: %1$S, Değiştirilmiş: %2$S, Kaldırılmış: %3$S).
+promtpDeleteDirectoryTitle=Kişiler klasörü kaldırılıyor?
+promptDeleteDirectoryText="%1$S" klasörünü kaldırmak istediğinize emin misiniz?

--- a/addressbook/locale/tr/addressbookOverlay.dtd
+++ b/addressbook/locale/tr/addressbookOverlay.dtd
@@ -1,0 +1,9 @@
+<!ENTITY toolbar.button.label.addaccount "Exchange kişiler klasörü ekle">
+<!ENTITY toolbar.button.tooltip.addaccount "Bu, yeni bir Exchange kişiler klasörü ekleyecektir">
+
+<!ENTITY toolbar.button.label.deleteaccount "Exchange kişiler klasörünü kaldır">
+<!ENTITY toolbar.button.tooltip.deleteaccount "Bu, bulunmakta olan bir Exchange kişiler klasörünü kaldıracaktır">
+
+<!ENTITY deleteExchangeCmd.label "Exchange kişiler klasörünü kaldır">
+
+

--- a/addressbook/locale/tr/exchangeContactSettings.dtd
+++ b/addressbook/locale/tr/exchangeContactSettings.dtd
@@ -1,0 +1,11 @@
+<!ENTITY label.acceptbutton "Kaydet">
+<!ENTITY label.cancelbutton "İptal Et">
+
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Toplantı talebi">
+
+<!ENTITY label.ecExchangeSettings.title "Listedeki isim:">
+<!ENTITY exchangeWebService.preference.contacts.pollinterval "Güncelleme aralığı (saniye):">
+
+<!ENTITY exchWebService.add.globaladdresslist.label "Arama sonuçlarına küresel adres listesini ekle.">
+

--- a/calendar/exchangeCalendar.manifest
+++ b/calendar/exchangeCalendar.manifest
@@ -28,16 +28,18 @@ manifest interface/exchangeEvent/mivExchangeEvent.manifest
 manifest interface/exchangeTodo/mivExchangeTodo.manifest
 manifest interface/exchangeRecurrenceInfo/mivExchangeRecurrenceInfo.manifest
 
-locale exchangecalendar en locale/en/
+locale exchangecalendar en    locale/en/
 
 locale exchangecalendar cs-CZ locale/cs_CZ/
-locale exchangecalendar de locale/de/
+locale exchangecalendar de    locale/de/
 locale exchangecalendar en-US locale/en_US/
 locale exchangecalendar fr-FR locale/fr_FR/
 locale exchangecalendar it-IT locale/it_IT/
 locale exchangecalendar ja-JP locale/ja_JP/
-locale exchangecalendar nl locale/nl/
-locale exchangecalendar ru locale/ru/
-locale exchangecalendar sv locale/sv/
-locale exchangecalendar tr locale/tr/
+locale exchangecalendar nl    locale/nl/
+locale exchangecalendar pl    locale/pl/
+locale exchangecalendar ru    locale/ru/
+locale exchangecalendar sk    locale/sk/
+locale exchangecalendar sv    locale/sv/
+locale exchangecalendar tr    locale/tr/
 

--- a/calendar/locale/pl/attachments-view.dtd
+++ b/calendar/locale/pl/attachments-view.dtd
@@ -1,0 +1,2 @@
+<!ENTITY exchWebServie.add.attachment.button.label "Attachments">
+

--- a/calendar/locale/pl/calendar-calendars-list.dtd
+++ b/calendar/locale/pl/calendar-calendars-list.dtd
@@ -1,0 +1,5 @@
+<!ENTITY calendar.context.exchange.convert.label "Convert to Exchange 2007/2010 Calendar and Tasks Add-on">
+<!ENTITY calendar.context.exchange.properties.label "Exchange (EWS) properties">
+<!ENTITY calendar.context.exchange.oof.settings.label "Out of office settings">
+<!ENTITY calendar.context.exchange.clone.settings.label "Clone settings to new calendar">
+<!ENTITY calendar.context.exchange.delegate.calendar.settings.label "Delegate calendar">

--- a/calendar/locale/pl/calendar-summary-dialog.dtd
+++ b/calendar/locale/pl/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required attendee">
+<!ENTITY optional.attendee.label "Optional attendee">

--- a/calendar/locale/pl/delegate-calendar-dialog.dtd
+++ b/calendar/locale/pl/delegate-calendar-dialog.dtd
@@ -1,0 +1,25 @@
+ 
+<!ENTITY  label.delegateCalendar.cancelbutton "Cancel">
+<!ENTITY  label.delegateCalendar.userEmail "Email">
+<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl "Deliver meeting requests">
+
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly "Delegates Only">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe "Delegates and Me">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo "Delegates and Send Notifications to Me">
+
+<!ENTITY  label.delegateCalendar.permission "Permission">
+<!ENTITY  menuitem.delegateCalendar.permission.author "Author">
+<!ENTITY  menuitem.delegateCalendar.permission.editor "Editor">
+<!ENTITY  menuitem.delegateCalendar.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegateCalendar.permission.none "None">
+
+<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy "Receive copies Of meeting messages" >
+<!ENTITY  label.delegateCalendar.permission.viewPrivateItems "View private items" >
+
+
+<!ENTITY  delegateCalendar.permission.description.author "Read and create items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.editor "Read, create, and modify items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.reviewer "Read items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.none "No access permissions to the calendar folder." >
+
+<!ENTITY  delegateCalendar.permission.details.label "Permission details: " >

--- a/calendar/locale/pl/ecCalendarCreation.dtd
+++ b/calendar/locale/pl/ecCalendarCreation.dtd
@@ -1,0 +1,5 @@
+<!ENTITY exchange1.description "Exchange/Windows Active Directory settings">
+<!ENTITY exchange.cache.label "Use offline cache">
+
+
+

--- a/calendar/locale/pl/exchangeReminderDialog.dtd
+++ b/calendar/locale/pl/exchangeReminderDialog.dtd
@@ -1,0 +1,4 @@
+<!ENTITY exchWebService.reminder.relation.origin.label "before the event starts">
+
+
+

--- a/calendar/locale/pl/lightning-item-iframe.dtd
+++ b/calendar/locale/pl/lightning-item-iframe.dtd
@@ -1,0 +1,7 @@
+<!ENTITY exchWebService.owner.label "Owner:">
+<!ENTITY exchWebService.totalWork.label "Total work:">
+<!ENTITY exchWebService.actualWork.label "Actual work:">
+<!ENTITY exchWebService.mileage.label "Mileage:">
+<!ENTITY exchWebService.billingInformation.label "Billing information:">
+<!ENTITY exchWebService.companies.label "Company:">
+

--- a/calendar/locale/pl/messenger_task_delegation.dtd
+++ b/calendar/locale/pl/messenger_task_delegation.dtd
@@ -1,0 +1,6 @@
+<!ENTITY exchWebService.task.delegation.owner.name "Task owner">
+<!ENTITY exchWebService.task.delegation.delegator.name "Task delegator">
+<!ENTITY exchWebService.task.delegation.accept.button "Accept">
+<!ENTITY exchWebService.task.delegation.decline.button "Decline">
+<!ENTITY exchWebService.task.delegation.lastUpdateDate "Last change on">
+

--- a/calendar/locale/sk/attachments-view.dtd
+++ b/calendar/locale/sk/attachments-view.dtd
@@ -1,0 +1,2 @@
+<!ENTITY exchWebServie.add.attachment.button.label "Attachments">
+

--- a/calendar/locale/sk/calendar-calendars-list.dtd
+++ b/calendar/locale/sk/calendar-calendars-list.dtd
@@ -1,0 +1,5 @@
+<!ENTITY calendar.context.exchange.convert.label "Convert to Exchange 2007/2010 Calendar and Tasks Add-on">
+<!ENTITY calendar.context.exchange.properties.label "Exchange (EWS) properties">
+<!ENTITY calendar.context.exchange.oof.settings.label "Out of office settings">
+<!ENTITY calendar.context.exchange.clone.settings.label "Clone settings to new calendar">
+<!ENTITY calendar.context.exchange.delegate.calendar.settings.label "Delegate calendar">

--- a/calendar/locale/sk/calendar-summary-dialog.dtd
+++ b/calendar/locale/sk/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required attendee">
+<!ENTITY optional.attendee.label "Optional attendee">

--- a/calendar/locale/sk/delegate-calendar-dialog.dtd
+++ b/calendar/locale/sk/delegate-calendar-dialog.dtd
@@ -1,0 +1,25 @@
+ 
+<!ENTITY  label.delegateCalendar.cancelbutton "Cancel">
+<!ENTITY  label.delegateCalendar.userEmail "Email">
+<!ENTITY  label.delegateCalendar.deliveryMeetingRerquestControl "Deliver meeting requests">
+
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateOnly "Delegates Only">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndMe "Delegates and Me">
+<!ENTITY  menuitem.delegateCalendar.deliverMeetingRequestslist.delegateAndInfo "Delegates and Send Notifications to Me">
+
+<!ENTITY  label.delegateCalendar.permission "Permission">
+<!ENTITY  menuitem.delegateCalendar.permission.author "Author">
+<!ENTITY  menuitem.delegateCalendar.permission.editor "Editor">
+<!ENTITY  menuitem.delegateCalendar.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegateCalendar.permission.none "None">
+
+<!ENTITY  label.delegateCalendar.permission.receiveInvitationCopy "Receive copies Of meeting messages" >
+<!ENTITY  label.delegateCalendar.permission.viewPrivateItems "View private items" >
+
+
+<!ENTITY  delegateCalendar.permission.description.author "Read and create items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.editor "Read, create, and modify items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.reviewer "Read items in the calendar folder." >
+<!ENTITY  delegateCalendar.permission.description.none "No access permissions to the calendar folder." >
+
+<!ENTITY  delegateCalendar.permission.details.label "Permission details: " >

--- a/calendar/locale/sk/ecCalendarCreation.dtd
+++ b/calendar/locale/sk/ecCalendarCreation.dtd
@@ -1,0 +1,5 @@
+<!ENTITY exchange1.description "Exchange/Windows Active Directory settings">
+<!ENTITY exchange.cache.label "Use offline cache">
+
+
+

--- a/calendar/locale/sk/exchangeReminderDialog.dtd
+++ b/calendar/locale/sk/exchangeReminderDialog.dtd
@@ -1,0 +1,4 @@
+<!ENTITY exchWebService.reminder.relation.origin.label "before the event starts">
+
+
+

--- a/calendar/locale/sk/lightning-item-iframe.dtd
+++ b/calendar/locale/sk/lightning-item-iframe.dtd
@@ -1,0 +1,7 @@
+<!ENTITY exchWebService.owner.label "Owner:">
+<!ENTITY exchWebService.totalWork.label "Total work:">
+<!ENTITY exchWebService.actualWork.label "Actual work:">
+<!ENTITY exchWebService.mileage.label "Mileage:">
+<!ENTITY exchWebService.billingInformation.label "Billing information:">
+<!ENTITY exchWebService.companies.label "Company:">
+

--- a/calendar/locale/sk/messenger_task_delegation.dtd
+++ b/calendar/locale/sk/messenger_task_delegation.dtd
@@ -1,0 +1,6 @@
+<!ENTITY exchWebService.task.delegation.owner.name "Task owner">
+<!ENTITY exchWebService.task.delegation.delegator.name "Task delegator">
+<!ENTITY exchWebService.task.delegation.accept.button "Accept">
+<!ENTITY exchWebService.task.delegation.decline.button "Decline">
+<!ENTITY exchWebService.task.delegation.lastUpdateDate "Last change on">
+

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -42,7 +42,9 @@ locale exchangecommon fr-FR common/locale/fr_FR/
 locale exchangecommon it-IT common/locale/it_IT/
 locale exchangecommon ja-JP common/locale/ja_JP/
 locale exchangecommon nl common/locale/nl/
+locale exchangecommon pl common/locale/pl/
 locale exchangecommon ru common/locale/ru/
+locale exchangecommon sk common/locale/sk/
 locale exchangecommon sv common/locale/sv/
 locale exchangecommon tr common/locale/tr/
 

--- a/common/locale/cs_CZ/preferences.dtd
+++ b/common/locale/cs_CZ/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Mezi jednotlivými požadavky na exchange server počkat alespoň:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Předvolby Ntlm-v1:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Zapnout">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Vypnout">

--- a/common/locale/de/preferences.dtd
+++ b/common/locale/de/preferences.dtd
@@ -42,6 +42,11 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximale gleichzeitige Zugriffe auf den Exchange-Server:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimale Wartezeit zwischen Zugriffen auf den Exchange-Server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP-User-Agent:">
+
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/fr_FR/preferences.dtd
+++ b/common/locale/fr_FR/preferences.dtd
@@ -42,6 +42,11 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Nombre Max de connexions simultanées vers le serveur Exchange:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Temps minimum entre les requètes vers le serveur Exchange:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
+
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Préférence Ntlm-v1:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "En service">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Hors service">

--- a/common/locale/it_IT/preferences.dtd
+++ b/common/locale/it_IT/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Tempo minimo di attesa fra richieste al server Exchange:">
 <!ENTITY exchangeWebService.preference.userAgent.label "Agente utente HTTP:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Opzioni NTLM-v1:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Abilita">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disabilita">

--- a/common/locale/ja_JP/preferences.dtd
+++ b/common/locale/ja_JP/preferences.dtd
@@ -35,13 +35,18 @@
 <!ENTITY exchangeWebService.preference.updateFunction.label "Addon update function:">
 <!ENTITY exchangeWebService.preference.checkForUpdates.label "Automatically check for a new addon version online when starting Thunderbird.">
 <!ENTITY exchangeWebService.preference.warnForUpdates.label "Show warning when a new version is available. So you can easily install it.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
 
 <!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Loadbalancer:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Loadbalancer:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximum number of simultanious request to exchange server:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time, to wait, between request to exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
-<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/nl/preferences.dtd
+++ b/common/locale/nl/preferences.dtd
@@ -35,13 +35,18 @@
 <!ENTITY exchangeWebService.preference.updateFunction.label "Addon update functie:">
 <!ENTITY exchangeWebService.preference.checkForUpdates.label "Controleer automatisch online voor een nieuwe versie als Thunderbird start.">
 <!ENTITY exchangeWebService.preference.warnForUpdates.label "Waarschuw als er een nieuwe versie beschikbaar is zodat je deze makelijk kan installeren.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
 
 <!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Loadbalancer:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Loadbalancer:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximaal aantal gelijktijdige verzoeken aan één exchange server:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimale tijd tussen verzoeken aan één exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
-<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/pl/browseFolder.dtd
+++ b/common/locale/pl/browseFolder.dtd
@@ -1,0 +1,12 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY browsefolder.title "Browse folders">
+
+<!ENTITY treecol.label.foldername "Folder name">
+<!ENTITY treecol.label.folderclass "Folder class">
+
+
+
+
+

--- a/common/locale/pl/calExchangeCalendar.properties
+++ b/common/locale/pl/calExchangeCalendar.properties
@@ -1,0 +1,49 @@
+displayName=Exchange 2007/2010 Calendar and Tasks Provider
+
+resetEventMessage=Calendar "%1$S" has been reset.
+addTaskEventMessage=Added task "%1$S" (%2$S).
+addCalendarEventMessage=Added appointment "%1$S" (%2$S).
+ewsErrorEventMessage=Error in communication with EWS server for "%1$S". Error: %2$S, Code: %3$S.
+updateCalendarEventMessage=Appointment "%1$S" has been modified (%2$S).
+updateTaskEventMessage=Task "%1$S" has been modified (%2$S).
+deleteCalendarEventMessage=Appointment "%1$S" has been removed (%2$S).
+deleteTaskEventMessage=Task "%1$S" has been removed (%2$S).
+syncFolderEventMessage="%4$S": Received updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxRequests="%4$S": Inbox received meeting invitation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxCancelations="%4$S": Inbox received meeting cancelation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxResponses="%4$S": Inbox received meeting response updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+ewsMeetingResponsEventMessage=Meeting request "%1$S" answered with "%2$S" (%3$S). Your message:
+
+ecErrorServerCheck=Error while checking with server: %1$S (%2$S)
+ecErrorAutodiscovery=Error during autodiscovery: %1$S (%2$S)
+ecErrorAutodiscoveryURLInvalid=It was not possible to find settings through autodiscovery using the domain name part of the mailbox (%1$S).\nUsually this means there is not an autodiscovery server defined with the domain name part as hostname.
+ecErrorServerCheckURLInvalid=Server "%1$S" does not exist.
+ecErrorServerAndMailboxCheck=Error during checking of server and mailbox: %1$S (Code: %2$S)
+
+updateUserPrefs1=User preferences updated for new version (since 0.7.26)
+
+autoRemoveConfirmedInvitationOnCancellation=Confirmed appointment "%1$S" has been canceled and was automatically removed as specified by user settings (%2$S).
+
+sendAutoRespondMeetingRequestMessage=Meeting request "%1$S" has been automatically answered as specified by the user settings (%2$S).
+
+ecLoadingOofSettings=(Retrieving data)
+ecLoadedOofSettings=(Data retrieved)
+ecErrorLoadingOofSettings=Error during loading of out of office settings. Code: %2$S, Message: %1$S.
+ecSavingOofSettings=(Saving data)
+ecSavedOofSettings=(Data saved)
+ecErrorSavingOofSettings=Error during saving of out of office settings. Code: %2$S, Message: %1$S.
+
+
+exchWebService.PidLidTaskHistory.duedate.changed=Due date was changed
+exchWebService.PidLidTaskHistory.some.property.changed=A property was changed
+exchWebService.PidLidTaskHistory.accepted=Task accepted by %1$S
+exchWebService.PidLidTaskHistory.rejected=Task rejected by %1$S
+exchWebService.PidLidTaskHistory.assigned=Task assigned to %1$S
+exchWebService.PidLidTaskHistory.no.changes=No changes
+
+ecErrorServerAndMailboxCheckFolderNotFound=Either you do not have read permission on the selected mailbox or the mailbox is incorrect.\n\nWhen the mailbox is corrected you might have permissions to view the busy/tentative/OOO user availability status for its calendar.\n\n(%2$S: %1$S)
+
+tooltipCalendarDisconnected=The calendar %1$S is not connected to the Exchange server\n(Reason: %2$S).
+tooltipCalendarDisconnectedReadOnly=The calendar %1$S is not connected to the Exchange server and is read only\n(Reason: %2$S).
+tooltipCalendarConnected=The calendar %1$S is connected to the Exchange server.
+tooltipCalendarConnectedReadOnly=The calendar %1$S is connected to the Exchange server and is readonly.

--- a/common/locale/pl/delegate-folder.dtd
+++ b/common/locale/pl/delegate-folder.dtd
@@ -1,0 +1,45 @@
+ 
+<!ENTITY  label.delegatefolder.cancelbutton "Cancel">
+<!ENTITY  label.delegatefolder.userEmail "Email">
+ 
+<!ENTITY  label.delegatefolder.permissionLevel "Permission level">
+<!ENTITY  label.delegatefolder.userboxcolumn1 "User"> 
+<!ENTITY  label.delegatefolder.userboxcolumn2 "Permissions"> 
+
+<!ENTITY  menuitem.delegatefolder.permission.author "Author">
+<!ENTITY  menuitem.delegatefolder.permission.editor "Editor">
+<!ENTITY  menuitem.delegatefolder.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegatefolder.permission.none "None">
+<!ENTITY  menuitem.delegatefolder.permission.owner "Owner" > 
+<!ENTITY  menuitem.delegatefolder.permission.publishingEditor "PublishingEditor" >
+<!ENTITY  menuitem.delegatefolder.permission.publishingAuthor "PublishingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.noneditingAuthor "NoneditingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.contributor "Contributor" >
+<!ENTITY  menuitem.delegatefolder.permission.custom "Custom" >
+                            
+<!ENTITY  delegatefolder.permission.description.author "Read and create items in the folder." >
+<!ENTITY  delegatefolder.permission.description.editor "Read, create, and modify items in the folder." >
+<!ENTITY  delegatefolder.permission.description.reviewer "Read items in the folder." >
+<!ENTITY  delegatefolder.permission.description.none "No access permissions to the folder." >
+
+ <!ENTITY  delegatefolder.permission.details.caption "Permission "> 
+
+<!ENTITY  delegatefolder.tab.msg.label  "No calendar or task found for this mail account.">
+<!ENTITY  delegatefolder.tab.name  "Exchange folder sharing">
+
+<!ENTITY  delegatefolder.permissions.none  "None">
+<!ENTITY  delegatefolder.permissions.own  "Own items">
+<!ENTITY  delegatefolder.permissions.all  "All items">
+<!ENTITY  delegatefolder.permissions.full  "Full details">
+
+<!ENTITY  delegatefolder.permissions.cancreateitems  "Create items">
+<!ENTITY  delegatefolder.permissions.cancreatesubfolders  "Create subfolders">
+<!ENTITY  delegatefolder.permissions.isfolderowner  "Folder owner">
+<!ENTITY  delegatefolder.permissions.isfoldervisible  "Folder visible">
+<!ENTITY  delegatefolder.permissions.isfoldercontact  "Folder contact">
+<!ENTITY  delegatefolder.permissions.edititems  "Edit items">
+<!ENTITY  delegatefolder.permissions.deleteitems  "Delete items">
+<!ENTITY  delegatefolder.permissions.readitems  "Read items">  
+ 
+<!ENTITY  delegatefolder.permissions.true  "True">
+<!ENTITY  delegatefolder.permissions.false  "False">

--- a/common/locale/pl/exchangeCloneSettings.dtd
+++ b/common/locale/pl/exchangeCloneSettings.dtd
@@ -1,0 +1,6 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.ecExchangeSettings.title "New description:">
+
+

--- a/common/locale/pl/exchangeSettings.dtd
+++ b/common/locale/pl/exchangeSettings.dtd
@@ -1,0 +1,54 @@
+<!ENTITY label.acceptbutton "Save and reset">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY ecsettings.title "EWS calendar and mail settings">
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting requests">
+<!ENTITY ecsettings.tab.calendarfolderproperties "Folder properties">
+
+<!ENTITY label.ecExchangeSettings.title "Settings for calendar:">
+
+<!ENTITY label.poll.inbox "Poll inbox for requests, changes and cancellations.">
+<!ENTITY label.poll.inbox.interval "Frequency (in seconds) to poll inbox:">
+<!ENTITY label.poll.calendar.interval "Frequency (in seconds) to poll calendar:">
+
+<!ENTITY label.nomeetingrequestsettings "You cannot set a meeting request because you did not select the main calendar for the mailbox">
+
+<!ENTITY label.autorespond.meetingrequest "Automatically respond to a new invitation with ">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.autoremove.invitation_cancellation1 "Automatically remove the invitation and accompanying cancelation message if you did not yet respond to the invitation request.">
+<!ENTITY label.autoremove.invitation_cancellation2 "Automatically remove a confirmed invitation when you receive a cancelation message.">
+
+<!ENTITY label.autoremove.invitation_response1 "Automatically remove a response from others to a meeting invitation of which you are not the organizer.">
+
+<!ENTITY label.doautorespond.meetingrequest.message "Send the following message with responses instead of asking for a message.">
+<!ENTITY label.autorespond.meetingrequest.message "Your message:">
+
+<!ENTITY treecol.label.userid "User ID">
+<!ENTITY treecol.label.email "Email">
+
+
+<!ENTITY ecsettings.tab.offlineCachingproperties "Offline caching">
+
+<!ENTITY label.offlineCacheproperties.cachingStartDate "Start date of caching:">
+<!ENTITY label.offlineCacheproperties.cachingEndDate "End date of caching:">
+<!ENTITY label.offlineCacheproperties.totalEvents "Total number of events cached:">
+<!ENTITY label.offlineCacheproperties.totalTasks "Total number of tasks cached:">
+
+<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate "Number of months to cache items prior to today:">
+<!ENTITY label.offlineCacheproperties.monthsBeforeEndDate "Number of months to cache items after today:">
+
+<!ENTITY button.offlineCacheproperties.clearCache "Clear offline cached data">
+<!ENTITY ecsettings.tab.autoprocessingproperties "Automatic processing">
+<!ENTITY ecsettings.tab.mailitemsProperties "EWS settings (mail)">
+
+<!ENTITY label.syncmailitems.interval "Delay syncing mail items (tags, etc.)">
+<!ENTITY label.autoprocessingproperties.deletecancelleditems "Automatically remove canceled events">
+<!ENTITY label.autoprocessingproperties.markeventtentative "Automatically mark event as tentative and send response to organizer">
+<!ENTITY label.syncmailitems.active "Keep enabled syncing mail items (tags, etc.)">
+
+<!ENTITY label.syncfollowup.deactivtate "Disable followup task">
+ 

--- a/common/locale/pl/exchangeSettingsOverlay.dtd
+++ b/common/locale/pl/exchangeSettingsOverlay.dtd
@@ -1,0 +1,56 @@
+<!ENTITY ecautodiscover "Use Exchange's autodiscovery function.">
+<!ENTITY ecfolderbase.label "Folder base:">
+<!ENTITY ecfolderpath.label "Path below folder base:">
+<!ENTITY ecfolderidofshare.label "Share Folder ID:">
+<!ENTITY exchWebServices.SharedFolderID.label "Shared display name:">
+
+<!ENTITY menuitem.label.ecfolderbase.calendar "Calendar folder">
+<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot "Public folders">
+<!ENTITY menuitem.label.ecfolderbase.inbox "Mail inbox folder">
+<!ENTITY menuitem.label.ecfolderbase.voicemail "Voice mail folder">
+<!ENTITY menuitem.label.ecfolderbase.msgfolderroot "Message folder root">
+<!ENTITY menuitem.label.ecfolderbase.root "Root of the mailbox">
+<!ENTITY menuitem.label.ecfolderbase.tasks "Tasks folder">
+
+<!ENTITY menuitem.label.ecfolderbase.contacts "Contacts folder">
+<!ENTITY menuitem.label.ecfolderbase.deleteditems "Deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.drafts "Drafts folder">
+<!ENTITY menuitem.label.ecfolderbase.journal "Journal folder">
+<!ENTITY menuitem.label.ecfolderbase.notes "Notes folder">
+<!ENTITY menuitem.label.ecfolderbase.outbox "Mail outbox folder">
+<!ENTITY menuitem.label.ecfolderbase.sentitems "Sent items folder">
+<!ENTITY menuitem.label.ecfolderbase.junkemail "Junk email folder">
+<!ENTITY menuitem.label.ecfolderbase.searchfolders "Search folders folder">
+<!ENTITY menuitem.label.ecfolderbase.version2010 "-- Options below are only for Exchange 2010 --">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot "Dumpster root folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions "Dumpster deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion "Dumpster versions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges "Dumpster purges folder">
+<!ENTITY menuitem.label.ecfolderbase.archiveroot "Root archive folder">
+<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot "Root archive message folder">
+<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems "Archive deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot "Archive recoverable items root folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsdeletions "Archive recoverable items deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsversions "Archive recoverable items versions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemspurges "Archive recoverable items purges folder">
+
+<!ENTITY button.label.autodiscovercheck "Perform autodiscovery">
+<!ENTITY button.label.serverandmailboxcheck "Check server and mailbox">
+<!ENTITY button.label.servercheck "Check server and account">
+
+<!ENTITY ecmailbox.label "Primary email address:">
+<!ENTITY ecmailbox.tooltip "If you do not specify a mailbox you will only have access to public folders.">
+<!ENTITY ecwindowsuser.label "Username:">
+<!ENTITY ecwindowsdomain.label "Domain name:">
+<!ENTITY ecwindowspassword.label "Password:">
+
+<!ENTITY button.label.folderpathcheck "Check">
+<!ENTITY button.label.folderbrowse "Browse">
+
+<!ENTITY exchWebServices.UserAvailability.label "Only user availability status for the mailbox's calendar will be visible.">
+
+<!ENTITY exchWebServices.exchtype.label "Exchange type">
+<!ENTITY exchWebServices.hostexch.label "Hosted Exchange">
+<!ENTITY exchWebServices.365exch.label "Microsoft Office 365">
+<!ENTITY exchWebServices.detail.label "Details">
+ 

--- a/common/locale/pl/extra-priority.dtd
+++ b/common/locale/pl/extra-priority.dtd
@@ -1,0 +1,18 @@
+<!ENTITY prefwindow.title "Extras">
+<!ENTITY general.label  "General"> 
+<!ENTITY about.label "About"> 
+ 
+<!ENTITY about.description.label "Enhanced Features for Thunderbird and SeaMonkey applications">
+<!ENTITY iconify.label "Display priority icons only"> 
+<!ENTITY shadeHigh.label "Color background for high-priority messages">
+<!ENTITY shadeLow.label "Color background for low-priority messages">
+<!ENTITY tagImportant.label "Automatically tag high-priority mail as important">
+ 
+<!ENTITY highestColor.label "Highest">
+
+<!ENTITY highColor.label "High">
+<!ENTITY lowColor.label "Low">
+<!ENTITY lowestColor.label "Lowest">
+ 
+<!ENTITY prioritycolor  "Custom Color">
+<!ENTITY pref.color "Color preferences:">

--- a/common/locale/pl/invitationResponse.dtd
+++ b/common/locale/pl/invitationResponse.dtd
@@ -1,0 +1,20 @@
+<!ENTITY label.acceptbutton "Confirm change">
+<!ENTITY label.cancelbutton "Cancel change">
+
+<!ENTITY description.invitationResponse "Confirm change of your meeting response.">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY label.messageReponseBody "Response message:">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.proposenewtime.title "Propose new time (&gt;= Exchange2013)">
+<!ENTITY label.proposenewtime.start "Start time">
+<!ENTITY label.proposenewtime.end "End time">

--- a/common/locale/pl/inviteStyle.dtd
+++ b/common/locale/pl/inviteStyle.dtd
@@ -1,0 +1,2 @@
+<!ENTITY label.inviteCol "Calendar invite">
+<!ENTITY tooltip.inviteCol "Sort by invitation">

--- a/common/locale/pl/manageEWSAccounts.dtd
+++ b/common/locale/pl/manageEWSAccounts.dtd
@@ -1,0 +1,16 @@
+<!ENTITY label.acceptbutton "Close">
+
+<!ENTITY exchWebService.manageEWSAccounts.newAccount.button "Add account">
+<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button "Remove account">
+<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Save settings">
+
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Use Exchange's autodiscovery function.">
+<!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailbox name:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Username:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domain name:">
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button "Perform autodiscovery">
+<!ENTITY exchWebService.manageEWSAccounts.servercheck.button "Check server and account">
+<!ENTITY exchWebService.manageEWSAccounts.name.label "Name:">
+
+<!ENTITY exchWebService.manageEWSAccounts.menuitem "Exchange Web Services accounts">
+

--- a/common/locale/pl/oofSettings.dtd
+++ b/common/locale/pl/oofSettings.dtd
@@ -1,0 +1,26 @@
+<!ENTITY title.oofsettings "Out of office settings">
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Close">
+<!ENTITY label.oofsettings.title "Out of office settings for:">
+
+<!ENTITY label.oofstatus "Out of office status:">
+
+<!ENTITY label.externalaudience "To which external persons do you want to send out of office messages: ">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none "To nobody">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known "Only to persons in my contact list">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all "To everybody">
+
+<!ENTITY button.label.internal "Internal message">
+<!ENTITY button.label.external "External message">
+<!ENTITY label.internalreply "Message that will be sent to people within my organization:">
+<!ENTITY label.externalreply "Message that will be sent to people outside my organization:">
+
+<!ENTITY menuitem.label.exchWebService-oof-status.disabled "Disabled">
+<!ENTITY menuitem.label.exchWebService-oof-status.enabled "Enabled">
+
+<!ENTITY checkbox.label.exchWebService-oof-scheduled "Only enabled in specified time frame:">
+<!ENTITY label.hbox-oof-scheduled-startTime "Start time:">
+<!ENTITY label.hbox-oof-scheduled-endTime "End time:">
+
+
+

--- a/common/locale/pl/preInvitationResponse.dtd
+++ b/common/locale/pl/preInvitationResponse.dtd
@@ -1,0 +1,14 @@
+<!ENTITY dialog.exchWebService.preInvitationResponse.title "How do you want to react?">
+<!ENTITY label.acceptbutton "OK">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY radio.label.exchWebService.preInvitationResponse.edit "Edit the response before sending.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow "Send the response now.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend "Don't send a response.">
+

--- a/common/locale/pl/preferences.dtd
+++ b/common/locale/pl/preferences.dtd
@@ -1,0 +1,48 @@
+<!ENTITY exchangeWebService.paneAccounts.title "Exchange (EWS)">
+<!ENTITY exchangeWebService.paneDebug.title "Logging">
+
+<!ENTITY exchangeWebService.preferences.tab.accounts "Accounts">
+<!ENTITY exchangeWebService.preferences.tab.debug "Logging">
+<!ENTITY exchangeWebService.preference.debug.file "Log file location:">
+<!ENTITY exchangeWebService.preference.network.debug.caption "Communication with Exchange server:">
+<!ENTITY exchangeWebService.preference.debug.log.label "Log information to the console and/or a file">
+<!ENTITY exchangeWebService.preference.debug.file.button "Browse">
+<!ENTITY exchangeWebService.preference.network.debug.label "Log communication with Exchange server">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.authentication.debug.label "Log communication progress information (e.g., Authentication)">
+<!ENTITY exchangeWebService.preference.authentication.showpassword.label "Show password in clear text in log file.">
+
+<!ENTITY exchangeWebService.preference.contacts.debug.caption "Addressbook/Contacts:">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.contacts.debug.label "Log info about addressbook/contacts part">
+
+<!ENTITY exchangeWebService.preferences.titleWin "Exchange (EWS) Preferences">
+
+<!ENTITY exchangeWebService.preference.core.debug.caption "Core provider object:">
+<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = None, 1 = Basic information, 2 = Extended information">
+
+<!ENTITY exchangeWebService.preferences.tab.cache "Caching">
+<!ENTITY exchangeWebService.preference.cache.memory.label "Minimal temporary memory cache">
+<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label "Number of days to download before start date of program:">
+<!ENTITY exchangeWebService.preference.cache.memory.startupAfter.label "Number of days to download after start date of program:">
+
+<!ENTITY exchangeWebService.preferences.tab.others "Others">
+<!ENTITY exchangeWebService.preference.others.prefs.label "Communication preferences:">
+<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label "Maximum number of retries for exchange communication:">
+
+<!ENTITY exchangeWebService.preference.updateFunction.label "Add-on update function:">
+<!ENTITY exchangeWebService.preference.checkForUpdates.label "Automatically check for a new add-on version online when starting Thunderbird.">
+<!ENTITY exchangeWebService.preference.warnForUpdates.label "Show warning when a new version is available so you can easily install it.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximum number of simultaneous request to exchange server:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
+<!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
+
+<!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
+<!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
+<!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/pl/preferences.dtd
+++ b/common/locale/pl/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/pl/selectEWSUrl.dtd
+++ b/common/locale/pl/selectEWSUrl.dtd
@@ -1,0 +1,9 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY description.selectews "Choose an EWS server from the list which is suitable for your current location.">
+<!ENTITY label.selectews "EWS server list:">
+
+
+
+

--- a/common/locale/pl/sendUpdateTo.dtd
+++ b/common/locale/pl/sendUpdateTo.dtd
@@ -1,0 +1,9 @@
+<!ENTITY title.sendupdateto "To whom do you want to send this update?">
+<!ENTITY label.acceptbutton "Execute">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY label.calendaritem.title "Send update for meeting:">
+
+<!ENTITY radio.label.sendtonone "Send to nobody.">
+<!ENTITY radio.label.sendtoall "Send to everyone invited.">
+<!ENTITY radio.label.sendtochanged "Send only to added or removed persons.">
+

--- a/common/locale/pl/sharedCalendarParser.dtd
+++ b/common/locale/pl/sharedCalendarParser.dtd
@@ -1,0 +1,3 @@
+<!ENTITY exchWebService_vbox_label "Detected an Exchange sharing invitation">
+<!ENTITY exchWebService_button_label_add_calendar "Add calendar">
+

--- a/common/locale/pl/timezonePreference.dtd
+++ b/common/locale/pl/timezonePreference.dtd
@@ -1,0 +1,1 @@
+<!ENTITY calendar.timezone.local.auto.label  "Automatically change timezone">

--- a/common/locale/ru/preferences.dtd
+++ b/common/locale/ru/preferences.dtd
@@ -35,6 +35,7 @@
 <!ENTITY exchangeWebService.preference.updateFunction.label "Функция обновления дополнения:">
 <!ENTITY exchangeWebService.preference.checkForUpdates.label "Автоматически проверять наличие новой версии дополнения онлайн при запуске Thunderbird.">
 <!ENTITY exchangeWebService.preference.warnForUpdates.label "Предупреждать, что доступна новая версия. Таким образом, вы можете легко установить ее.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
 
 <!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Балансировка нагрузки:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Балансировка нагрузки:">
@@ -42,8 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Минимальное время ожидания между запросами exchange сервера:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP агент пользователя:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
 
-<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/sk/browseFolder.dtd
+++ b/common/locale/sk/browseFolder.dtd
@@ -1,0 +1,12 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY browsefolder.title "Browse folders">
+
+<!ENTITY treecol.label.foldername "Folder name">
+<!ENTITY treecol.label.folderclass "Folder class">
+
+
+
+
+

--- a/common/locale/sk/calExchangeCalendar.properties
+++ b/common/locale/sk/calExchangeCalendar.properties
@@ -1,0 +1,49 @@
+displayName=Exchange 2007/2010 Calendar and Tasks Provider
+
+resetEventMessage=Calendar "%1$S" has been reset.
+addTaskEventMessage=Added task "%1$S" (%2$S).
+addCalendarEventMessage=Added appointment "%1$S" (%2$S).
+ewsErrorEventMessage=Error in communication with EWS server for "%1$S". Error: %2$S, Code: %3$S.
+updateCalendarEventMessage=Appointment "%1$S" has been modified (%2$S).
+updateTaskEventMessage=Task "%1$S" has been modified (%2$S).
+deleteCalendarEventMessage=Appointment "%1$S" has been removed (%2$S).
+deleteTaskEventMessage=Task "%1$S" has been removed (%2$S).
+syncFolderEventMessage="%4$S": Received updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxRequests="%4$S": Inbox received meeting invitation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxCancelations="%4$S": Inbox received meeting cancelation updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+syncInboxResponses="%4$S": Inbox received meeting response updates from EWS server (New: %1$S, Changed: %2$S, Deleted: %3$S).
+ewsMeetingResponsEventMessage=Meeting request "%1$S" answered with "%2$S" (%3$S). Your message:
+
+ecErrorServerCheck=Error while checking with server: %1$S (%2$S)
+ecErrorAutodiscovery=Error during autodiscovery: %1$S (%2$S)
+ecErrorAutodiscoveryURLInvalid=It was not possible to find settings through autodiscovery using the domain name part of the mailbox (%1$S).\nUsually this means there is not an autodiscovery server defined with the domain name part as hostname.
+ecErrorServerCheckURLInvalid=Server "%1$S" does not exist.
+ecErrorServerAndMailboxCheck=Error during checking of server and mailbox: %1$S (Code: %2$S)
+
+updateUserPrefs1=User preferences updated for new version (since 0.7.26)
+
+autoRemoveConfirmedInvitationOnCancellation=Confirmed appointment "%1$S" has been canceled and was automatically removed as specified by user settings (%2$S).
+
+sendAutoRespondMeetingRequestMessage=Meeting request "%1$S" has been automatically answered as specified by the user settings (%2$S).
+
+ecLoadingOofSettings=(Retrieving data)
+ecLoadedOofSettings=(Data retrieved)
+ecErrorLoadingOofSettings=Error during loading of out of office settings. Code: %2$S, Message: %1$S.
+ecSavingOofSettings=(Saving data)
+ecSavedOofSettings=(Data saved)
+ecErrorSavingOofSettings=Error during saving of out of office settings. Code: %2$S, Message: %1$S.
+
+
+exchWebService.PidLidTaskHistory.duedate.changed=Due date was changed
+exchWebService.PidLidTaskHistory.some.property.changed=A property was changed
+exchWebService.PidLidTaskHistory.accepted=Task accepted by %1$S
+exchWebService.PidLidTaskHistory.rejected=Task rejected by %1$S
+exchWebService.PidLidTaskHistory.assigned=Task assigned to %1$S
+exchWebService.PidLidTaskHistory.no.changes=No changes
+
+ecErrorServerAndMailboxCheckFolderNotFound=Either you do not have read permission on the selected mailbox or the mailbox is incorrect.\n\nWhen the mailbox is corrected you might have permissions to view the busy/tentative/OOO user availability status for its calendar.\n\n(%2$S: %1$S)
+
+tooltipCalendarDisconnected=The calendar %1$S is not connected to the Exchange server\n(Reason: %2$S).
+tooltipCalendarDisconnectedReadOnly=The calendar %1$S is not connected to the Exchange server and is read only\n(Reason: %2$S).
+tooltipCalendarConnected=The calendar %1$S is connected to the Exchange server.
+tooltipCalendarConnectedReadOnly=The calendar %1$S is connected to the Exchange server and is readonly.

--- a/common/locale/sk/delegate-folder.dtd
+++ b/common/locale/sk/delegate-folder.dtd
@@ -1,0 +1,45 @@
+ 
+<!ENTITY  label.delegatefolder.cancelbutton "Cancel">
+<!ENTITY  label.delegatefolder.userEmail "Email">
+ 
+<!ENTITY  label.delegatefolder.permissionLevel "Permission level">
+<!ENTITY  label.delegatefolder.userboxcolumn1 "User"> 
+<!ENTITY  label.delegatefolder.userboxcolumn2 "Permissions"> 
+
+<!ENTITY  menuitem.delegatefolder.permission.author "Author">
+<!ENTITY  menuitem.delegatefolder.permission.editor "Editor">
+<!ENTITY  menuitem.delegatefolder.permission.reviewer "Reviewer">
+<!ENTITY  menuitem.delegatefolder.permission.none "None">
+<!ENTITY  menuitem.delegatefolder.permission.owner "Owner" > 
+<!ENTITY  menuitem.delegatefolder.permission.publishingEditor "PublishingEditor" >
+<!ENTITY  menuitem.delegatefolder.permission.publishingAuthor "PublishingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.noneditingAuthor "NoneditingAuthor" >
+<!ENTITY  menuitem.delegatefolder.permission.contributor "Contributor" >
+<!ENTITY  menuitem.delegatefolder.permission.custom "Custom" >
+                            
+<!ENTITY  delegatefolder.permission.description.author "Read and create items in the folder." >
+<!ENTITY  delegatefolder.permission.description.editor "Read, create, and modify items in the folder." >
+<!ENTITY  delegatefolder.permission.description.reviewer "Read items in the folder." >
+<!ENTITY  delegatefolder.permission.description.none "No access permissions to the folder." >
+
+ <!ENTITY  delegatefolder.permission.details.caption "Permission "> 
+
+<!ENTITY  delegatefolder.tab.msg.label  "No calendar or task found for this mail account.">
+<!ENTITY  delegatefolder.tab.name  "Exchange folder sharing">
+
+<!ENTITY  delegatefolder.permissions.none  "None">
+<!ENTITY  delegatefolder.permissions.own  "Own items">
+<!ENTITY  delegatefolder.permissions.all  "All items">
+<!ENTITY  delegatefolder.permissions.full  "Full details">
+
+<!ENTITY  delegatefolder.permissions.cancreateitems  "Create items">
+<!ENTITY  delegatefolder.permissions.cancreatesubfolders  "Create subfolders">
+<!ENTITY  delegatefolder.permissions.isfolderowner  "Folder owner">
+<!ENTITY  delegatefolder.permissions.isfoldervisible  "Folder visible">
+<!ENTITY  delegatefolder.permissions.isfoldercontact  "Folder contact">
+<!ENTITY  delegatefolder.permissions.edititems  "Edit items">
+<!ENTITY  delegatefolder.permissions.deleteitems  "Delete items">
+<!ENTITY  delegatefolder.permissions.readitems  "Read items">  
+ 
+<!ENTITY  delegatefolder.permissions.true  "True">
+<!ENTITY  delegatefolder.permissions.false  "False">

--- a/common/locale/sk/exchangeCloneSettings.dtd
+++ b/common/locale/sk/exchangeCloneSettings.dtd
@@ -1,0 +1,6 @@
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.ecExchangeSettings.title "New description:">
+
+

--- a/common/locale/sk/exchangeSettings.dtd
+++ b/common/locale/sk/exchangeSettings.dtd
@@ -1,0 +1,54 @@
+<!ENTITY label.acceptbutton "Save and reset">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY ecsettings.title "EWS calendar and mail settings">
+<!ENTITY ecsettings.tab.adsettings "Exchange/Windows AD">
+<!ENTITY ecsettings.tab.meetingrequestsettings "Meeting requests">
+<!ENTITY ecsettings.tab.calendarfolderproperties "Folder properties">
+
+<!ENTITY label.ecExchangeSettings.title "Settings for calendar:">
+
+<!ENTITY label.poll.inbox "Poll inbox for requests, changes and cancellations.">
+<!ENTITY label.poll.inbox.interval "Frequency (in seconds) to poll inbox:">
+<!ENTITY label.poll.calendar.interval "Frequency (in seconds) to poll calendar:">
+
+<!ENTITY label.nomeetingrequestsettings "You cannot set a meeting request because you did not select the main calendar for the mailbox">
+
+<!ENTITY label.autorespond.meetingrequest "Automatically respond to a new invitation with ">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.autoremove.invitation_cancellation1 "Automatically remove the invitation and accompanying cancelation message if you did not yet respond to the invitation request.">
+<!ENTITY label.autoremove.invitation_cancellation2 "Automatically remove a confirmed invitation when you receive a cancelation message.">
+
+<!ENTITY label.autoremove.invitation_response1 "Automatically remove a response from others to a meeting invitation of which you are not the organizer.">
+
+<!ENTITY label.doautorespond.meetingrequest.message "Send the following message with responses instead of asking for a message.">
+<!ENTITY label.autorespond.meetingrequest.message "Your message:">
+
+<!ENTITY treecol.label.userid "User ID">
+<!ENTITY treecol.label.email "Email">
+
+
+<!ENTITY ecsettings.tab.offlineCachingproperties "Offline caching">
+
+<!ENTITY label.offlineCacheproperties.cachingStartDate "Start date of caching:">
+<!ENTITY label.offlineCacheproperties.cachingEndDate "End date of caching:">
+<!ENTITY label.offlineCacheproperties.totalEvents "Total number of events cached:">
+<!ENTITY label.offlineCacheproperties.totalTasks "Total number of tasks cached:">
+
+<!ENTITY label.offlineCacheproperties.monthsBeforeStartDate "Number of months to cache items prior to today:">
+<!ENTITY label.offlineCacheproperties.monthsBeforeEndDate "Number of months to cache items after today:">
+
+<!ENTITY button.offlineCacheproperties.clearCache "Clear offline cached data">
+<!ENTITY ecsettings.tab.autoprocessingproperties "Automatic processing">
+<!ENTITY ecsettings.tab.mailitemsProperties "EWS settings (mail)">
+
+<!ENTITY label.syncmailitems.interval "Delay syncing mail items (tags, etc.)">
+<!ENTITY label.autoprocessingproperties.deletecancelleditems "Automatically remove canceled events">
+<!ENTITY label.autoprocessingproperties.markeventtentative "Automatically mark event as tentative and send response to organizer">
+<!ENTITY label.syncmailitems.active "Keep enabled syncing mail items (tags, etc.)">
+
+<!ENTITY label.syncfollowup.deactivtate "Disable followup task">
+ 

--- a/common/locale/sk/exchangeSettingsOverlay.dtd
+++ b/common/locale/sk/exchangeSettingsOverlay.dtd
@@ -1,0 +1,56 @@
+<!ENTITY ecautodiscover "Use Exchange's autodiscovery function.">
+<!ENTITY ecfolderbase.label "Folder base:">
+<!ENTITY ecfolderpath.label "Path below folder base:">
+<!ENTITY ecfolderidofshare.label "Share Folder ID:">
+<!ENTITY exchWebServices.SharedFolderID.label "Shared display name:">
+
+<!ENTITY menuitem.label.ecfolderbase.calendar "Calendar folder">
+<!ENTITY menuitem.label.ecfolderbase.publicfoldersroot "Public folders">
+<!ENTITY menuitem.label.ecfolderbase.inbox "Mail inbox folder">
+<!ENTITY menuitem.label.ecfolderbase.voicemail "Voice mail folder">
+<!ENTITY menuitem.label.ecfolderbase.msgfolderroot "Message folder root">
+<!ENTITY menuitem.label.ecfolderbase.root "Root of the mailbox">
+<!ENTITY menuitem.label.ecfolderbase.tasks "Tasks folder">
+
+<!ENTITY menuitem.label.ecfolderbase.contacts "Contacts folder">
+<!ENTITY menuitem.label.ecfolderbase.deleteditems "Deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.drafts "Drafts folder">
+<!ENTITY menuitem.label.ecfolderbase.journal "Journal folder">
+<!ENTITY menuitem.label.ecfolderbase.notes "Notes folder">
+<!ENTITY menuitem.label.ecfolderbase.outbox "Mail outbox folder">
+<!ENTITY menuitem.label.ecfolderbase.sentitems "Sent items folder">
+<!ENTITY menuitem.label.ecfolderbase.junkemail "Junk email folder">
+<!ENTITY menuitem.label.ecfolderbase.searchfolders "Search folders folder">
+<!ENTITY menuitem.label.ecfolderbase.version2010 "-- Options below are only for Exchange 2010 --">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsroot "Dumpster root folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsdeletions "Dumpster deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemsversion "Dumpster versions folder">
+<!ENTITY menuitem.label.ecfolderbase.recoverableitemspurges "Dumpster purges folder">
+<!ENTITY menuitem.label.ecfolderbase.archiveroot "Root archive folder">
+<!ENTITY menuitem.label.ecfolderbase.archivemsgfolderroot "Root archive message folder">
+<!ENTITY menuitem.label.ecfolderbase.archivedeleteditems "Archive deleted items folder">
+<!ENTITY menuitem.label.ecfolderbase.archiverecoverableitemsroot "Archive recoverable items root folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsdeletions "Archive recoverable items deletions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemsversions "Archive recoverable items versions folder">
+<!ENTITY menuitem.label.ecfolderbase.Archiverecoverableitemspurges "Archive recoverable items purges folder">
+
+<!ENTITY button.label.autodiscovercheck "Perform autodiscovery">
+<!ENTITY button.label.serverandmailboxcheck "Check server and mailbox">
+<!ENTITY button.label.servercheck "Check server and account">
+
+<!ENTITY ecmailbox.label "Primary email address:">
+<!ENTITY ecmailbox.tooltip "If you do not specify a mailbox you will only have access to public folders.">
+<!ENTITY ecwindowsuser.label "Username:">
+<!ENTITY ecwindowsdomain.label "Domain name:">
+<!ENTITY ecwindowspassword.label "Password:">
+
+<!ENTITY button.label.folderpathcheck "Check">
+<!ENTITY button.label.folderbrowse "Browse">
+
+<!ENTITY exchWebServices.UserAvailability.label "Only user availability status for the mailbox's calendar will be visible.">
+
+<!ENTITY exchWebServices.exchtype.label "Exchange type">
+<!ENTITY exchWebServices.hostexch.label "Hosted Exchange">
+<!ENTITY exchWebServices.365exch.label "Microsoft Office 365">
+<!ENTITY exchWebServices.detail.label "Details">
+ 

--- a/common/locale/sk/extra-priority.dtd
+++ b/common/locale/sk/extra-priority.dtd
@@ -1,0 +1,18 @@
+<!ENTITY prefwindow.title "Extras">
+<!ENTITY general.label  "General"> 
+<!ENTITY about.label "About"> 
+ 
+<!ENTITY about.description.label "Enhanced Features for Thunderbird and SeaMonkey applications">
+<!ENTITY iconify.label "Display priority icons only"> 
+<!ENTITY shadeHigh.label "Color background for high-priority messages">
+<!ENTITY shadeLow.label "Color background for low-priority messages">
+<!ENTITY tagImportant.label "Automatically tag high-priority mail as important">
+ 
+<!ENTITY highestColor.label "Highest">
+
+<!ENTITY highColor.label "High">
+<!ENTITY lowColor.label "Low">
+<!ENTITY lowestColor.label "Lowest">
+ 
+<!ENTITY prioritycolor  "Custom Color">
+<!ENTITY pref.color "Color preferences:">

--- a/common/locale/sk/invitationResponse.dtd
+++ b/common/locale/sk/invitationResponse.dtd
@@ -1,0 +1,20 @@
+<!ENTITY label.acceptbutton "Confirm change">
+<!ENTITY label.cancelbutton "Cancel change">
+
+<!ENTITY description.invitationResponse "Confirm change of your meeting response.">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY label.messageReponseBody "Response message:">
+
+<!ENTITY menuitem.label.ec-autorespond-answer.tentative "I might attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.accepted "I will attend">
+<!ENTITY menuitem.label.ec-autorespond-answer.declined "I will not attend">
+
+<!ENTITY label.proposenewtime.title "Propose new time (&gt;= Exchange2013)">
+<!ENTITY label.proposenewtime.start "Start time">
+<!ENTITY label.proposenewtime.end "End time">

--- a/common/locale/sk/inviteStyle.dtd
+++ b/common/locale/sk/inviteStyle.dtd
@@ -1,0 +1,2 @@
+<!ENTITY label.inviteCol "Calendar invite">
+<!ENTITY tooltip.inviteCol "Sort by invitation">

--- a/common/locale/sk/manageEWSAccounts.dtd
+++ b/common/locale/sk/manageEWSAccounts.dtd
@@ -1,0 +1,16 @@
+<!ENTITY label.acceptbutton "Close">
+
+<!ENTITY exchWebService.manageEWSAccounts.newAccount.button "Add account">
+<!ENTITY exchWebService.manageEWSAccounts.removeAccount.button "Remove account">
+<!ENTITY exchWebService.manageEWSAccounts.saveAccount.button "Save settings">
+
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.label "Use Exchange's autodiscovery function.">
+<!ENTITY exchWebService.manageEWSAccounts.mailbox.label "Mailbox name:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsuser.label "Username:">
+<!ENTITY exchWebService.manageEWSAccounts.windowsdomain.label "Domain name:">
+<!ENTITY exchWebService.manageEWSAccounts.autodiscover.button "Perform autodiscovery">
+<!ENTITY exchWebService.manageEWSAccounts.servercheck.button "Check server and account">
+<!ENTITY exchWebService.manageEWSAccounts.name.label "Name:">
+
+<!ENTITY exchWebService.manageEWSAccounts.menuitem "Exchange Web Services accounts">
+

--- a/common/locale/sk/oofSettings.dtd
+++ b/common/locale/sk/oofSettings.dtd
@@ -1,0 +1,26 @@
+<!ENTITY title.oofsettings "Out of office settings">
+<!ENTITY label.acceptbutton "Save">
+<!ENTITY label.cancelbutton "Close">
+<!ENTITY label.oofsettings.title "Out of office settings for:">
+
+<!ENTITY label.oofstatus "Out of office status:">
+
+<!ENTITY label.externalaudience "To which external persons do you want to send out of office messages: ">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.none "To nobody">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.known "Only to persons in my contact list">
+<!ENTITY menuitem.label.exchWebService-oof-externalaudience.all "To everybody">
+
+<!ENTITY button.label.internal "Internal message">
+<!ENTITY button.label.external "External message">
+<!ENTITY label.internalreply "Message that will be sent to people within my organization:">
+<!ENTITY label.externalreply "Message that will be sent to people outside my organization:">
+
+<!ENTITY menuitem.label.exchWebService-oof-status.disabled "Disabled">
+<!ENTITY menuitem.label.exchWebService-oof-status.enabled "Enabled">
+
+<!ENTITY checkbox.label.exchWebService-oof-scheduled "Only enabled in specified time frame:">
+<!ENTITY label.hbox-oof-scheduled-startTime "Start time:">
+<!ENTITY label.hbox-oof-scheduled-endTime "End time:">
+
+
+

--- a/common/locale/sk/preInvitationResponse.dtd
+++ b/common/locale/sk/preInvitationResponse.dtd
@@ -1,0 +1,14 @@
+<!ENTITY dialog.exchWebService.preInvitationResponse.title "How do you want to react?">
+<!ENTITY label.acceptbutton "OK">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY label.calendarName "Calendar:">
+<!ENTITY label.itemTitle "Subject:">
+<!ENTITY label.itemStart "Start time:">
+<!ENTITY label.itemResponse "Your response:">
+<!ENTITY label.meetingOrganiser "Organizer:">
+
+<!ENTITY radio.label.exchWebService.preInvitationResponse.edit "Edit the response before sending.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.sendnow "Send the response now.">
+<!ENTITY radio.label.exchWebService.preInvitationResponse.donotsend "Don't send a response.">
+

--- a/common/locale/sk/preferences.dtd
+++ b/common/locale/sk/preferences.dtd
@@ -1,0 +1,48 @@
+<!ENTITY exchangeWebService.paneAccounts.title "Exchange (EWS)">
+<!ENTITY exchangeWebService.paneDebug.title "Logging">
+
+<!ENTITY exchangeWebService.preferences.tab.accounts "Accounts">
+<!ENTITY exchangeWebService.preferences.tab.debug "Logging">
+<!ENTITY exchangeWebService.preference.debug.file "Log file location:">
+<!ENTITY exchangeWebService.preference.network.debug.caption "Communication with Exchange server:">
+<!ENTITY exchangeWebService.preference.debug.log.label "Log information to the console and/or a file">
+<!ENTITY exchangeWebService.preference.debug.file.button "Browse">
+<!ENTITY exchangeWebService.preference.network.debug.label "Log communication with Exchange server">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.network.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.authentication.debug.label "Log communication progress information (e.g., Authentication)">
+<!ENTITY exchangeWebService.preference.authentication.showpassword.label "Show password in clear text in log file.">
+
+<!ENTITY exchangeWebService.preference.contacts.debug.caption "Addressbook/Contacts:">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label1 "Log level">
+<!ENTITY exchangeWebService.preference.contacts.debuglevel.label2 "1 = Basic information, 2 = Complete communication">
+<!ENTITY exchangeWebService.preference.contacts.debug.label "Log info about addressbook/contacts part">
+
+<!ENTITY exchangeWebService.preferences.titleWin "Exchange (EWS) Preferences">
+
+<!ENTITY exchangeWebService.preference.core.debug.caption "Core provider object:">
+<!ENTITY exchangeWebService.preference.core.debuglevel.label2 "0 = None, 1 = Basic information, 2 = Extended information">
+
+<!ENTITY exchangeWebService.preferences.tab.cache "Caching">
+<!ENTITY exchangeWebService.preference.cache.memory.label "Minimal temporary memory cache">
+<!ENTITY exchangeWebService.preference.cache.memory.startupBefore.label "Number of days to download before start date of program:">
+<!ENTITY exchangeWebService.preference.cache.memory.startupAfter.label "Number of days to download after start date of program:">
+
+<!ENTITY exchangeWebService.preferences.tab.others "Others">
+<!ENTITY exchangeWebService.preference.others.prefs.label "Communication preferences:">
+<!ENTITY exchangeWebService.preference.others.prefs.retryCount.label "Maximum number of retries for exchange communication:">
+
+<!ENTITY exchangeWebService.preference.updateFunction.label "Add-on update function:">
+<!ENTITY exchangeWebService.preference.checkForUpdates.label "Automatically check for a new add-on version online when starting Thunderbird.">
+<!ENTITY exchangeWebService.preference.warnForUpdates.label "Show warning when a new version is available so you can easily install it.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Loadbalancer:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximum number of simultaneous request to exchange server:">
+<!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
+<!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
+
+<!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
+<!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
+<!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/sk/preferences.dtd
+++ b/common/locale/sk/preferences.dtd
@@ -43,6 +43,10 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minimum time to wait between requests to Exchange server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "NTLM-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/sk/selectEWSUrl.dtd
+++ b/common/locale/sk/selectEWSUrl.dtd
@@ -1,0 +1,9 @@
+<!ENTITY label.acceptbutton "Select">
+<!ENTITY label.cancelbutton "Cancel">
+
+<!ENTITY description.selectews "Choose an EWS server from the list which is suitable for your current location.">
+<!ENTITY label.selectews "EWS server list:">
+
+
+
+

--- a/common/locale/sk/sendUpdateTo.dtd
+++ b/common/locale/sk/sendUpdateTo.dtd
@@ -1,0 +1,9 @@
+<!ENTITY title.sendupdateto "To whom do you want to send this update?">
+<!ENTITY label.acceptbutton "Execute">
+<!ENTITY label.cancelbutton "Cancel">
+<!ENTITY label.calendaritem.title "Send update for meeting:">
+
+<!ENTITY radio.label.sendtonone "Send to nobody.">
+<!ENTITY radio.label.sendtoall "Send to everyone invited.">
+<!ENTITY radio.label.sendtochanged "Send only to added or removed persons.">
+

--- a/common/locale/sk/sharedCalendarParser.dtd
+++ b/common/locale/sk/sharedCalendarParser.dtd
@@ -1,0 +1,3 @@
+<!ENTITY exchWebService_vbox_label "Detected an Exchange sharing invitation">
+<!ENTITY exchWebService_button_label_add_calendar "Add calendar">
+

--- a/common/locale/sk/timezonePreference.dtd
+++ b/common/locale/sk/timezonePreference.dtd
@@ -1,0 +1,1 @@
+<!ENTITY calendar.timezone.local.auto.label  "Automatically change timezone">

--- a/common/locale/sv/preferences.dtd
+++ b/common/locale/sv/preferences.dtd
@@ -35,13 +35,18 @@
 <!ENTITY exchangeWebService.preference.updateFunction.label "Uppdateringsfunktion för tillägg:">
 <!ENTITY exchangeWebService.preference.checkForUpdates.label "Kontrollera automatiskt om en ny version av tillägget finns tillgänglig när Thunderbird startar.">
 <!ENTITY exchangeWebService.preference.warnForUpdates.label "Visa ett varningsmeddelande när en ny version finns tillgänglig.">
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
 
 <!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "Lastbalansering:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "Lastbalansering:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.maxJobs.label "Maximalt antal samtidiga förfrågningar mot Exchange-server:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Minsta väntetid mellan förfrågningar mot Exchange-server:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP user agent:">
-<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Show warning when a new pre-release (beta, RC, etc.) is available.">
+
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
+
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Preferences:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Enable">
 <!ENTITY exchangeWebService.preference.ntlmv1.false.label "Disable">

--- a/common/locale/tr/preferences.dtd
+++ b/common/locale/tr/preferences.dtd
@@ -35,7 +35,7 @@
 <!ENTITY exchangeWebService.preference.updateFunction.label "Eklenti güncelleme işlevi:">
 <!ENTITY exchangeWebService.preference.checkForUpdates.label "Thunderbird başlarken yen bir eklenti sürümü olup olmadığını otomatik olarak denetle.">
 <!ENTITY exchangeWebService.preference.warnForUpdates.label "Sürümleri kolayca yükleyebilmeniz için, yeni bir sürüm olduğunda bir uyarı göster.">
-<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Beta, rc, vs. gibi yeni bir ön sürüm mevcut olduğunda bir uyarı göster."> 
+<!ENTITY exchangeWebService.preference.warnForPrereleaseUpdates.label "Beta, rc, vs. gibi yeni bir ön sürüm mevcut olduğunda bir uyarı göster.">
 
 <!ENTITY exchangeWebService.preference.loadbalancer.debug.caption "YükDengeleyici:">
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.label "YükDengeleyici:">
@@ -43,6 +43,9 @@
 <!ENTITY exchangeWebService.preference.loadbalancer.prefs.sleepBetweenJobs.label "Exchange sunucuna gönderilen istekler arasındaki en kısa bekleme süresi:">
 <!ENTITY exchangeWebService.preference.userAgent.label "HTTP kullanıcı aracısı:">
 
+<!ENTITY exchangeWebService.preference.globalsearch.caption "Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.label "Enable the Thunderbird Global Search Index">
+<!ENTITY exchangeWebService.preference.globalsearch.explain "If you enable this Thunderbird feature, exchangecalendar would be able to enable the email remote tagging and the invitation column in the mail tree view.">
 
 <!ENTITY exchangeWebService.preference.ntlmv1.label "Ntlm-v1 Tercihleri:">
 <!ENTITY exchangeWebService.preference.ntlmv1.true.label "Etkinleştir">

--- a/emailtag/exchangeEmailTag.manifest
+++ b/emailtag/exchangeEmailTag.manifest
@@ -4,10 +4,15 @@ overlay chrome://messenger/content/messenger.xul chrome://exchangeemailtag/conte
 
 locale exchangeemailtag en    locale/en/
 
+locale exchangeemailtag cs-CZ locale/cs_CZ/
 locale exchangeemailtag de    locale/de/
 locale exchangeemailtag en-US locale/en_US/
 locale exchangeemailtag fr-FR locale/fr_FR/
+locale exchangeemailtag it-IT locale/it_IT/
 locale exchangeemailtag ja-JP locale/ja_JP/
 locale exchangeemailtag nl    locale/nl/
+locale exchangeemailtag pl    locale/pl/
 locale exchangeemailtag ru    locale/ru/
+locale exchangeemailtag sk    locale/sk/
 locale exchangeemailtag sv    locale/sv/
+locale exchangeemailtag tr    locale/tr/

--- a/emailtag/locale/de/emailtag.properties
+++ b/emailtag/locale/de/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=Fehler beim Anlegen des Tags für die Kategorie

--- a/emailtag/locale/ja_JP/emailtag.properties
+++ b/emailtag/locale/ja_JP/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category

--- a/emailtag/locale/nl/emailtag.properties
+++ b/emailtag/locale/nl/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category

--- a/emailtag/locale/pl/emailtag.dtd
+++ b/emailtag/locale/pl/emailtag.dtd
@@ -1,0 +1,15 @@
+ <!ENTITY rtews.selectaccountdesc "Select Microsoft Exchange mail account for which to configure.">
+ <!ENTITY rtews.accconfigured "Account already configured">
+ <!ENTITY rtews.dicoverdesc "You may choose to autodiscover the Exchange Web Services (EWS) URL or configure it manually">
+ <!ENTITY rtews.dicoverdesc2 "To configure it manually enter the URL in the field below.">
+ <!ENTITY rtews.autodiscover "Autodiscover">
+ <!ENTITY rtews.doautodicover "Do autodiscovery">
+ <!ENTITY rtews.manual "Manual">
+ <!ENTITY rtews.test "Click here to verify the EWS URL">
+ <!ENTITY rtews.msexchewsurl "Verified EWS URL. Click Finish to complete the configuration">
+ <!ENTITY rtews.selectaccount "Select account">
+ <!ENTITY rtews.configure.label "Configure...">
+ <!ENTITY rtews.rtforexch "Remote tagger for Microsoft Exchange">
+ <!ENTITY rtews.confirmAccDetail "Confirm following account details">
+ <!ENTITY rtews.username "Username">
+ <!ENTITY rtews.domain "Domain">

--- a/emailtag/locale/pl/emailtag.properties
+++ b/emailtag/locale/pl/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category

--- a/emailtag/locale/ru/emailtag.properties
+++ b/emailtag/locale/ru/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category

--- a/emailtag/locale/sk/emailtag.dtd
+++ b/emailtag/locale/sk/emailtag.dtd
@@ -1,0 +1,15 @@
+ <!ENTITY rtews.selectaccountdesc "Select Microsoft Exchange mail account for which to configure.">
+ <!ENTITY rtews.accconfigured "Account already configured">
+ <!ENTITY rtews.dicoverdesc "You may choose to autodiscover the Exchange Web Services (EWS) URL or configure it manually">
+ <!ENTITY rtews.dicoverdesc2 "To configure it manually enter the URL in the field below.">
+ <!ENTITY rtews.autodiscover "Autodiscover">
+ <!ENTITY rtews.doautodicover "Do autodiscovery">
+ <!ENTITY rtews.manual "Manual">
+ <!ENTITY rtews.test "Click here to verify the EWS URL">
+ <!ENTITY rtews.msexchewsurl "Verified EWS URL. Click Finish to complete the configuration">
+ <!ENTITY rtews.selectaccount "Select account">
+ <!ENTITY rtews.configure.label "Configure...">
+ <!ENTITY rtews.rtforexch "Remote tagger for Microsoft Exchange">
+ <!ENTITY rtews.confirmAccDetail "Confirm following account details">
+ <!ENTITY rtews.username "Username">
+ <!ENTITY rtews.domain "Domain">

--- a/emailtag/locale/sk/emailtag.properties
+++ b/emailtag/locale/sk/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category

--- a/emailtag/locale/sv/emailtag.properties
+++ b/emailtag/locale/sv/emailtag.properties
@@ -1,0 +1,2 @@
+rtews.title=EWStagger
+rtews.tagAddError=There was an error creating the tag for the category


### PR DESCRIPTION
Translations have been updated and enabled.

An option has been added to `l10n-push` Makefile target to send only the `en` locale to Transifex.
That means that now translation will be always fetched from Transifex.

Changelog has been updated too with changes since beta4.