### PR TITLE
Strings from calExchangeCalendar.properties are located in the exchangecommon namespace

### DIFF
--- a/calendar/content/messenger_task_delegation.js
+++ b/calendar/content/messenger_task_delegation.js
@@ -114,22 +114,22 @@ exchTaskDelegation.prototype = {
                 var lastChange = task.getProperty("exchWebService-PidLidTaskHistory");
                 switch (lastChange) {
                 case "4":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.duedate.changed", [], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.duedate.changed", [], "exchangecommon");
                     break;
                 case "3":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.some.property.changed", [], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.some.property.changed", [], "exchangecommon");
                     break;
                 case "1":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.accepted", [task.getProperty("exchWebService-Owner")], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.accepted", [task.getProperty("exchWebService-Owner")], "exchangecommon");
                     break;
                 case "2":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.rejected", [task.getProperty("exchWebService-Owner")], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.rejected", [task.getProperty("exchWebService-Owner")], "exchangecommon");
                     break;
                 case "5":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.assigned", [task.getProperty("exchWebService-Owner")], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.assigned", [task.getProperty("exchWebService-Owner")], "exchangecommon");
                     break;
                 case "0":
-                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.no.changes", [], "exchangecalendar");
+                    lastChange = this.globalFunctions.getString("calExchangeCalendar", "exchWebService.PidLidTaskHistory.no.changes", [], "exchangecommon");
                     break;
                 }
 

--- a/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
+++ b/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
@@ -495,7 +495,7 @@ calExchangeCalendar.prototype = {
 
     get displayName() {
         if (this.debug) this.logInfo("get displayName()");
-        return calGetString("calExchangeCalendar", "displayName", null, "exchangecalendar");
+        return calGetString("calExchangeCalendar", "displayName", null, "exchangecommon");
     },
 
     //  void createCalendar(in AUTF8String aName, in nsIURI aURL,
@@ -3748,17 +3748,17 @@ calExchangeCalendar.prototype = {
         this.saveCredentials(erSyncFolderItemsRequest.argument);
 
         if ((creations.meetingrequests.length > 0) || (updates.meetingrequests.length > 0) || (deletions.meetingrequests.length > 0)) {
-            this.addActivity(calGetString("calExchangeCalendar", "syncInboxRequests", [creations.meetingrequests.length, updates.meetingrequests.length, deletions.meetingrequests.length, this.name], "exchangecalendar"), "", erSyncInboxRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "syncInboxRequests", [creations.meetingrequests.length, updates.meetingrequests.length, deletions.meetingrequests.length, this.name], "exchangecommon"), "", erSyncInboxRequest.argument.actionStart, Date.now());
             this.refresh();
         }
 
         if ((creations.meetingCancellations.length > 0) || (updates.meetingCancellations.length > 0) || (deletions.meetingCancellations.length > 0)) {
-            this.addActivity(calGetString("calExchangeCalendar", "syncInboxCancelations", [creations.meetingCancellations.length, updates.meetingCancellations.length, deletions.meetingCancellations.length, this.name], "exchangecalendar"), "", erSyncInboxRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "syncInboxCancelations", [creations.meetingCancellations.length, updates.meetingCancellations.length, deletions.meetingCancellations.length, this.name], "exchangecommon"), "", erSyncInboxRequest.argument.actionStart, Date.now());
             this.refresh();
         }
 
         if ((creations.meetingResponses.length > 0) || (updates.meetingResponses.length > 0) || (deletions.meetingResponses.length > 0)) {
-            this.addActivity(calGetString("calExchangeCalendar", "syncInboxResponses", [creations.meetingResponses.length, updates.meetingResponses.length, deletions.meetingResponses.length, this.name], "exchangecalendar"), "", erSyncInboxRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "syncInboxResponses", [creations.meetingResponses.length, updates.meetingResponses.length, deletions.meetingResponses.length, this.name], "exchangecommon"), "", erSyncInboxRequest.argument.actionStart, Date.now());
             this.refresh();
         }
 
@@ -3920,7 +3920,7 @@ calExchangeCalendar.prototype = {
                         var bodyText = null;
                         if (this.sendAutoRespondMeetingRequestMessage) {
                             bodyText = this.autoRespondMeetingRequestMessage;
-                            this.addActivity(calGetString("calExchangeCalendar", "sendAutoRespondMeetingRequestMessage", [index.title, this.name], "exchangecalendar"), "", Date.now(), Date.now());
+                            this.addActivity(calGetString("calExchangeCalendar", "sendAutoRespondMeetingRequestMessage", [index.title, this.name], "exchangecommon"), "", Date.now(), Date.now());
 
                         }
 
@@ -4032,7 +4032,7 @@ calExchangeCalendar.prototype = {
                                 // Remove calendar item and cancellation message
                                 // because user specified so in the EWS settings.
                                 // We remove it from the real calendar and in the inbox.
-                                this.addActivity(calGetString("calExchangeCalendar", "autoRemoveConfirmedInvitationOnCancellation", [inCalendar.title, this.name], "exchangecalendar"), "", Date.now(), Date.now());
+                                this.addActivity(calGetString("calExchangeCalendar", "autoRemoveConfirmedInvitationOnCancellation", [inCalendar.title, this.name], "exchangecommon"), "", Date.now(), Date.now());
                                 inCalendar.setProperty("X-IsCancelled", true);
                                 this.deleteItem(inCalendar);
                                 this.removeMeetingItem(index);
@@ -4409,7 +4409,7 @@ calExchangeCalendar.prototype = {
             + Ci.calICalendar.ITEM_FILTER_TYPE_EVENT, 0, oldBeginDate, oldEndDate, null);
 
         // Make an event for thistory.
-        this.addActivity(calGetString("calExchangeCalendar", "resetEventMessage", [this.name], "exchangecalendar"), "", this.resetStart, Date.now());
+        this.addActivity(calGetString("calExchangeCalendar", "resetEventMessage", [this.name], "exchangecommon"), "", this.resetStart, Date.now());
         if (this.debug) this.logInfo(" performReset 2");
     },
 
@@ -5439,11 +5439,11 @@ calExchangeCalendar.prototype = {
 
         // Make an event for thistory.
         if (isEvent(erCreateItemRequest.argument.item)) {
-            this.addActivity(calGetString("calExchangeCalendar", "addCalendarEventMessage", [erCreateItemRequest.argument.item.title, this.name], "exchangecalendar"), "", erCreateItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "addCalendarEventMessage", [erCreateItemRequest.argument.item.title, this.name], "exchangecommon"), "", erCreateItemRequest.argument.actionStart, Date.now());
         }
         else {
             //this.notifyTheObservers("onAddItem", [newItem]);
-            this.addActivity(calGetString("calExchangeCalendar", "addTaskEventMessage", [erCreateItemRequest.argument.item.title, this.name], "exchangecalendar"), "", erCreateItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "addTaskEventMessage", [erCreateItemRequest.argument.item.title, this.name], "exchangecommon"), "", erCreateItemRequest.argument.actionStart, Date.now());
         }
 
 
@@ -5745,7 +5745,7 @@ calExchangeCalendar.prototype = {
             //this.meetingrequestAnswered[erSendMeetingResponsRequest.argument.item.uid] = false;
         }
 
-        this.addActivity(calGetString("calExchangeCalendar", "ewsMeetingResponsEventMessage", [erSendMeetingResponsRequest.argument.item.title, erSendMeetingResponsRequest.argument.response, this.name], "exchangecalendar"), erSendMeetingResponsRequest.argument.bodyText, erSendMeetingResponsRequest.argument.actionStart, Date.now());
+        this.addActivity(calGetString("calExchangeCalendar", "ewsMeetingResponsEventMessage", [erSendMeetingResponsRequest.argument.item.title, erSendMeetingResponsRequest.argument.response, this.name], "exchangecommon"), erSendMeetingResponsRequest.argument.bodyText, erSendMeetingResponsRequest.argument.actionStart, Date.now());
         this.refresh();
     },
 
@@ -5872,7 +5872,7 @@ calExchangeCalendar.prototype = {
             }
         }
         else {
-            this.addActivity(calGetString("calExchangeCalendar", "ewsErrorEventMessage", [this.name, aMsg, aCode], "exchangecalendar"), aMsg, erGetOccurrenceIndexRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "ewsErrorEventMessage", [this.name, aMsg, aCode], "exchangecommon"), aMsg, erGetOccurrenceIndexRequest.argument.actionStart, Date.now());
 
             var promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"]
                 .getService(Components.interfaces.nsIPromptService);
@@ -6008,10 +6008,10 @@ calExchangeCalendar.prototype = {
 
         // Make an event for thistory.
         if (isEvent(erUpdateItemRequest.argument.newItem)) {
-            this.addActivity(calGetString("calExchangeCalendar", "updateCalendarEventMessage", [erUpdateItemRequest.argument.newItem.title, this.name], "exchangecalendar"), "", erUpdateItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "updateCalendarEventMessage", [erUpdateItemRequest.argument.newItem.title, this.name], "exchangecommon"), "", erUpdateItemRequest.argument.actionStart, Date.now());
         }
         else {
-            this.addActivity(calGetString("calExchangeCalendar", "updateTaskEventMessage", [erUpdateItemRequest.argument.newItem.title, this.name], "exchangecalendar"), "", erUpdateItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "updateTaskEventMessage", [erUpdateItemRequest.argument.newItem.title, this.name], "exchangecommon"), "", erUpdateItemRequest.argument.actionStart, Date.now());
         }
 
         if (!this.doAttachmentUpdates(erUpdateItemRequest.argument.attachmentsUpdates, erUpdateItemRequest.argument.item, erUpdateItemRequest.argument.sendto, erUpdateItemRequest.listener)) {
@@ -6113,10 +6113,10 @@ calExchangeCalendar.prototype = {
 
 
         if (isEvent(erDeleteItemRequest.argument.item)) {
-            this.addActivity(calGetString("calExchangeCalendar", "deleteCalendarEventMessage", [erDeleteItemRequest.argument.item.title, this.name], "exchangecalendar"), "", erDeleteItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "deleteCalendarEventMessage", [erDeleteItemRequest.argument.item.title, this.name], "exchangecommon"), "", erDeleteItemRequest.argument.actionStart, Date.now());
         }
         else {
-            this.addActivity(calGetString("calExchangeCalendar", "deleteTaskEventMessage", [erDeleteItemRequest.argument.item.title, this.name], "exchangecalendar"), "", erDeleteItemRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "deleteTaskEventMessage", [erDeleteItemRequest.argument.item.title, this.name], "exchangecommon"), "", erDeleteItemRequest.argument.actionStart, Date.now());
         }
 
         //delete erDeleteItemRequest.argument.item;
@@ -8272,7 +8272,7 @@ else { dump("Occurrence does not exist in cache anymore.\n");}
         if (this.debug) this.logInfo("syncFolderItemsOK: Folderbase: " + erSyncFolderItemsRequest.folderBase + ", Creation:" + creations.length + ", Updates:" + updates.length + ", Deletions:" + deletions.length + ", syncState:" + syncState);
 
         if ((creations.length > 0) || (updates.length > 0) || (deletions.length > 0)) {
-            this.addActivity(calGetString("calExchangeCalendar", "syncFolderEventMessage", [creations.length, updates.length, deletions.length, this.name], "exchangecalendar"), "", erSyncFolderItemsRequest.argument.actionStart, Date.now());
+            this.addActivity(calGetString("calExchangeCalendar", "syncFolderEventMessage", [creations.length, updates.length, deletions.length, this.name], "exchangecommon"), "", erSyncFolderItemsRequest.argument.actionStart, Date.now());
         }
 
         if (syncState) {

--- a/common/content/exchangeSettingsOverlay.js
+++ b/common/content/exchangeSettingsOverlay.js
@@ -416,10 +416,10 @@ exchSettingsOverlay.prototype = {
         case -30:
             break;
         case -6:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecommon"));
         }
         this._document.getElementById("exchWebService_serverandmailboxcheckbutton").disabled = false;
         this.exchWebServicesCheckRequired();
@@ -437,7 +437,7 @@ exchSettingsOverlay.prototype = {
             this._document.getElementById("exchWebServices-SharedFolderID-label").value = aExchangeRequest.displayName;
         }
         else {
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecommon"));
         }
 
         this._document.getElementById("exchWebService_serverandmailboxcheckbutton").disabled = false;
@@ -453,10 +453,10 @@ exchSettingsOverlay.prototype = {
         case -30:
             break;
         case -6:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecommon"));
         }
         this._document.getElementById("exchWebService_serverandmailboxcheckbutton").disabled = false;
         this.exchWebServicesCheckRequired();
@@ -485,7 +485,7 @@ exchSettingsOverlay.prototype = {
         case -30:
             break;
         case -6:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecommon"));
             break;
         case -7:
         case -208: // folderNotFound. 
@@ -494,7 +494,7 @@ exchSettingsOverlay.prototype = {
         case -212:
             aMsg = aMsg + "(" + this.exchWebServicesgMailbox + ")";
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecommon"));
         }
         this._document.getElementById("exchWebService_serverandmailboxcheckbutton").disabled = false;
         this.exchWebServicesCheckRequired();
@@ -543,7 +543,7 @@ exchSettingsOverlay.prototype = {
         this.globalFunctions.LOG("checkUserAvailabilityError");
         this.gexchWebServicesDetailsChecked = false;
 
-        alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecalendar"));
+        alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerAndMailboxCheck", [aMsg, aCode], "exchangecommon"));
 
         this._document.getElementById("exchWebService_serverandmailboxcheckbutton").disabled = false;
         this.exchWebServicesCheckRequired();
@@ -602,10 +602,10 @@ exchSettingsOverlay.prototype = {
         case -30:
             break;
         case -6:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [this.exchWebServicesgServer], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheck", [aMsg, aCode], "exchangecommon"));
         }
         this._document.getElementById("exchWebService_servercheckbutton").disabled = false;
 
@@ -749,10 +749,10 @@ exchSettingsOverlay.prototype = {
         case -16:
         case -17:
         case -18:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscoveryURLInvalid", [this.exchWebServicesgMailbox], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscoveryURLInvalid", [this.exchWebServicesgMailbox], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscovery", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscovery", [aMsg, aCode], "exchangecommon"));
         }
 
         this._document.getElementById("exchWebService_autodiscovercheckbutton").disabled = false;

--- a/common/content/manageEWSAccounts.js
+++ b/common/content/manageEWSAccounts.js
@@ -363,10 +363,10 @@ exchWebService.manageEWSAccounts = {
         case -16:
         case -17:
         case -18:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscoveryURLInvalid", [document.getElementById("exchWebService_mailbox").value], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscoveryURLInvalid", [document.getElementById("exchWebService_mailbox").value], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscovery", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorAutodiscovery", [aMsg, aCode], "exchangecommon"));
         }
 
         document.getElementById("exchWebService_autodiscovercheckbutton").disabled = false;
@@ -411,10 +411,10 @@ exchWebService.manageEWSAccounts = {
         case -30:
             break;
         case -6:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [document.getElementById("exchWebService_server").value], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheckURLInvalid", [document.getElementById("exchWebService_server").value], "exchangecommon"));
             break;
         default:
-            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheck", [aMsg, aCode], "exchangecalendar"));
+            alert(this.globalFunctions.getString("calExchangeCalendar", "ecErrorServerCheck", [aMsg, aCode], "exchangecommon"));
         }
         document.getElementById("exchWebService_servercheckbutton").disabled = false;
 

--- a/common/content/oofSettings.js
+++ b/common/content/oofSettings.js
@@ -90,7 +90,7 @@ exchOOFSettings.prototype = {
     },
 
     getOofSettings: function _getOofSettings() {
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecLoadingOofSettings", [], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecLoadingOofSettings", [], "exchangecommon");
 
         var self = this;
         var tmpObject = new erGetUserOofSettingsRequest({
@@ -112,7 +112,7 @@ exchOOFSettings.prototype = {
         this.globalFunctions.LOG("intern:" + this.intOofSettings.internalReply);
         this.globalFunctions.LOG("extern:" + this.intOofSettings.externalReply);
 
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecLoadedOofSettings", [], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecLoadedOofSettings", [], "exchangecommon");
 
         this._document.getElementById("exchWebService_oofSettings_dialog").buttons = "accept,cancel";
 
@@ -154,7 +154,7 @@ exchOOFSettings.prototype = {
     },
 
     getOofSettingsError: function _getOofSettingsError(aGetUserOofSettingsRequest, aCode, aMsg) {
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecErrorLoadingOofSettings", [aMsg, aCode], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecErrorLoadingOofSettings", [aMsg, aCode], "exchangecommon");
     },
 
     doScheduledChanged: function _doScheduledChanged() {
@@ -166,7 +166,7 @@ exchOOFSettings.prototype = {
     },
 
     setOofSettings: function _setOofSettings() {
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecSavingOofSettings", [], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecSavingOofSettings", [], "exchangecommon");
 
         var oofState = "Disabled";
         if (this._document.getElementById("exchWebService-oof-status").value == "Enabled") {
@@ -227,14 +227,14 @@ exchOOFSettings.prototype = {
     },
 
     setOofSettingsOK: function _setOofSettingsOK(aGetUserOofSettingsRequest) {
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecSavedOofSettings", [], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecSavedOofSettings", [], "exchangecommon");
         this.infoPopup(this._document.title, "Settings saved.");
         this.getOofSettings();
 
     },
 
     setOofSettingsError: function _setOofSettingsError(aGetUserOofSettingsRequest, aCode, aMsg) {
-        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecErrorSavingOofSettings", [aMsg, aCode], "exchangecalendar");
+        this._document.getElementById("exchWebService-load-error-message").value = this.globalFunctions.getString("calExchangeCalendar", "ecErrorSavingOofSettings", [aMsg, aCode], "exchangecommon");
         alert("Error saving settings. Msg:" + aMsg + ", Code:" + aCode);
 
         this.getOofSettings();


### PR DESCRIPTION
With code tree reorganization, default namespace is now exchangecommon.

The file calExchangeCalendar.properties is used inside common parts like
exchange settings and out of office settings.

It's also used in calendar part to give user some information about
current calendar synchronization jobs.

I've decided to just modify JavaScript code to use the new namespace
instead of moving the properties file, because:
  - It only required to modify 48 lines of code
  - If I've chosen to move the file to the exchangecalendar namespace
    I would done a dependency from the common part to the calendar part.
  - To split the file in two parts, it would require too lot of work to
    synchronize the split between all translated files.

Closes #152