### PR TITLE
fix priority-display.js to get correctly preferences from Thunderbird branches

### DIFF
--- a/common/content/priority-display.js
+++ b/common/content/priority-display.js
@@ -31,13 +31,13 @@ function tag(hdr) {
 function gCP(pref) {
     var prefService = Cc["@mozilla.org/preferences-service;1"]
         .getService(Ci.nsIPrefService);
-    return prefService.getCharPref("extensions.extras." + pref);
+    return prefService.getBranch("extensions.extras.").getCharPref(pref);
 }
 
 function gBP(pref) {
     var prefService = Cc["@mozilla.org/preferences-service;1"]
         .getService(Ci.nsIPrefService);
-    return prefService.getBoolPref("extensions.extras." + pref);
+    return prefService.getBranch("extensions.extras.").getBoolPref(pref);
 }
 
 function toggleMessageTagPostEwsUpdate(key, addKey, hdr) {


### PR DESCRIPTION
It fixes some errors appearing in console about for `priority-display.js` line 40.

The fix just does correctly use of [nsIPrefService](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefService) and [nsIPrefBranch](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefBranch) interfaces from Mozilla.