### PR TITLE
mivExchangeAuthPrompt2: fix syntax typo

### DIFF
--- a/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
+++ b/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
@@ -614,7 +614,7 @@ mivExchangeAuthPrompt2.prototype = {
      *				result == false when password not found.
      */
     passwordManagerGet: function _passwordManagerGet(aUsername, aURL, aRealm) {
-        if ((!aUsername) || aUsername.trim() == "")) {
+        if ((!aUsername) || aUsername.trim() == "") {
             this.logInfo("passwordManagerGet: username is undefined or empty.")
             return {
                 result: false


### PR DESCRIPTION
A typo introduced with PR #155 , sorry.