### PR TITLE
mivFunctions.js: LOG now uses ISO format to write current time in logs (in UTC timezone)

### DIFF
--- a/common/interface/global/mivFunctions.js
+++ b/common/interface/global/mivFunctions.js
@@ -407,9 +407,6 @@ mivFunctions.prototype = {
     },
 
     LOG: function _LOG(aArg) {
-        //var prefB = Cc["@mozilla.org/preferences-service;1"].
-        //            getService(Ci.nsIPrefBranch);
-        //var shouldLog = this.safeGetBoolPref(prefB, "extensions.1st-setup.debug.log", false, true);
 
         if (!this.shouldLog()) {
             return;
@@ -433,7 +430,7 @@ mivFunctions.prototype = {
         }
         else {
             var dt = new Date();
-            string = "1st-setup:" + dt.getFullYear() + "-" + dt.getMonth() + "-" + dt.getDay() + " " + dt.getHours() + ":" + dt.getMinutes() + ":" + dt.getSeconds() + "." + dt.getMilliseconds() + ":" + aArg;
+            string = "ExchangeCalendar [" + dt.toISOString() + "]: " + aArg;
         }
 
         // xxx todo consider using function debug()


### PR DESCRIPTION
I took the opportunity to prefix with `ExchangeCalendar` instead of `1st-setup:` too.

Now, logs, looks like:

> ExchangeCalendar [2018-02-05T22:55:28.158Z]: 4f792b62-b071-4e14-97f8-8ed6eb37786c:   --- ecnsIAuthPrompt2.onProgress: this is a nsIChannel

Closes #107 