### PR TITLE
replace use of obsolete makeURL by Services.io.newURI

### DIFF
--- a/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
+++ b/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
@@ -6746,7 +6746,7 @@ calExchangeCalendar.prototype = {
 
                     var newAttachment = createAttachment();
                     newAttachment.setParameter("X-AttachmentId", fileAttachment.getAttributeByTag("t:AttachmentId", "Id"));
-                    newAttachment.uri = makeURL(this.serverUrl + "/?id=" + encodeURIComponent(fileAttachment.getAttributeByTag("t:AttachmentId", "Id")) + "&name=" + encodeURIComponent(fileAttachment.getTagValue("t:Name")) + "&size=" + encodeURIComponent(fileAttachment.getTagValue("t:Size", "")) + "&user=" + encodeURIComponent(this.user));
+                    newAttachment.uri = Services.io.newURI(this.serverUrl + "/?id=" + encodeURIComponent(fileAttachment.getAttributeByTag("t:AttachmentId", "Id")) + "&name=" + encodeURIComponent(fileAttachment.getTagValue("t:Name")) + "&size=" + encodeURIComponent(fileAttachment.getTagValue("t:Size", "")) + "&user=" + encodeURIComponent(this.user));
 
                     this.logInfo("New attachment URI:" + this.serverUrl + "/?id=" + encodeURIComponent(fileAttachment.getAttributeByTag("t:AttachmentId", "Id")) + "&name=" + encodeURIComponent(fileAttachment.getTagValue("t:Name")) + "&size=" + encodeURIComponent(fileAttachment.getTagValue("t:Size", "")) + "&user=" + encodeURIComponent(this.user));
 

--- a/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
+++ b/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
@@ -2891,7 +2891,7 @@ mivExchangeBaseItem.prototype = {
                 for (var fileAttachment of Object.values(fileAttachments)) {
                     var newAttachment = cal.createAttachment();
                     newAttachment.setParameter("X-AttachmentId", xml2json.getAttributeByTag(fileAttachment, "t:AttachmentId", "Id"));
-                    newAttachment.uri = cal.makeURL("http://somewhere/?id=" + encodeURIComponent(xml2json.getAttributeByTag(fileAttachment, "t:AttachmentId", "Id")) + "&name=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:Name")) + "&size=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:Size", "")) + "&calendarid=" + encodeURIComponent(this.calendar.id) + "&isinline=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:IsInline", "false")) + "&contentid=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:ContentId", "<NOPE>")));
+                    newAttachment.uri = Services.io.newURI("http://somewhere/?id=" + encodeURIComponent(xml2json.getAttributeByTag(fileAttachment, "t:AttachmentId", "Id")) + "&name=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:Name")) + "&size=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:Size", "")) + "&calendarid=" + encodeURIComponent(this.calendar.id) + "&isinline=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:IsInline", "false")) + "&contentid=" + encodeURIComponent(xml2json.getTagValue(fileAttachment, "t:ContentId", "<NOPE>")));
 
                     this._attachments.push(newAttachment.clone());
                     this._calEvent.addAttachment(newAttachment);


### PR DESCRIPTION
Try to fix #203  after user report of invalid makeURL method.

I wasn't able to reproduce the bug, but Lightning has already modified their code with a patch like this one. (see bug report of Lightning inside commit message).