### PR TITLE
Replace versioned JavaScript script type which has been removed from …

### DIFF
--- a/calendar/content/delegateCalendar.xul
+++ b/calendar/content/delegateCalendar.xul
@@ -20,7 +20,7 @@
         buttons="cancel"
         ondialogcancel="window.close();"
         onload="tmpDelegateCalendarSettings.onLoad();">
-    <script type="application/x-javascript"
+    <script type="application/javascript"
             src="chrome://exchangecommon/content/adutils.js" />
     <script type="application/javascript"
             src="chrome://exchangecalendar/content/delegateCalendar.js" />

--- a/common/content/sharedCalendarParser.xul
+++ b/common/content/sharedCalendarParser.xul
@@ -45,7 +45,7 @@
          xmlns:html="http://www.w3.org/1999/xhtml"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-    <script type="application/x-javascript"
+    <script type="application/javascript"
             src="chrome://exchangecommon/content/sharedCalendarParser.js" />
     <vbox id="messagepanebox">
         <vbox position="1">


### PR DESCRIPTION
…TB 57

According to migration documentation:

> versioned Javascript support -- replacement: In XUL files, links to JS files using <script type="application/x-javascript" ... > or <script type="application/x-javascript;version=1.7" ... >, change to <script type="application/javascript" ... >

https://wiki.mozilla.org/Thunderbird/Add-ons_Guide_57