### PR TITLE
Import from chromeutils

### DIFF
--- a/addressbook/content/abCardOverlay.js
+++ b/addressbook/content/abCardOverlay.js
@@ -26,14 +26,14 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/mailServices.js");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
-Cu.import("resource://exchangecommon/erGetAttachments.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangecommon/erGetAttachments.js");
 
 var photoHandlerInline = {
     onLoad: function _onLoad(aCard, aDocument) {

--- a/addressbook/content/abCardOverlay.js
+++ b/addressbook/content/abCardOverlay.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/content/addressbookOverlay.js
+++ b/addressbook/content/addressbookOverlay.js
@@ -26,14 +26,14 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/mailServices.js");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
-Cu.import("resource://exchangecommon/erGetAttachments.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangecommon/erGetAttachments.js");
 
 function exchAddressbookOverlay(aDocument, aWindow) {
     this._document = aDocument;

--- a/addressbook/content/addressbookOverlay.js
+++ b/addressbook/content/addressbookOverlay.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/content/exchangeContactSettings.js
+++ b/addressbook/content/exchangeContactSettings.js
@@ -24,7 +24,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 function exchExchangeContactSettings(aDocument, aWindow) {
     this._document = aDocument;

--- a/addressbook/content/exchangeContactsInit.js
+++ b/addressbook/content/exchangeContactsInit.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/exchangeapi/erExpandDL.js
+++ b/addressbook/exchangeapi/erExpandDL.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/exchangeapi/erExpandDL.js
+++ b/addressbook/exchangeapi/erExpandDL.js
@@ -26,12 +26,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erExpandDLRequest"];
 

--- a/addressbook/exchangeapi/erFindContacts.js
+++ b/addressbook/exchangeapi/erFindContacts.js
@@ -22,12 +22,12 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindContactsRequest"];
 

--- a/addressbook/exchangeapi/erFindContacts.js
+++ b/addressbook/exchangeapi/erFindContacts.js
@@ -20,7 +20,7 @@
  *
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/addressbook/exchangeapi/erGetContacts.js
+++ b/addressbook/exchangeapi/erGetContacts.js
@@ -26,12 +26,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetContactsRequest"];
 

--- a/addressbook/exchangeapi/erGetContacts.js
+++ b/addressbook/exchangeapi/erGetContacts.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/exchangeapi/erResolveNames.js
+++ b/addressbook/exchangeapi/erResolveNames.js
@@ -26,12 +26,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erResolveNames"];
 

--- a/addressbook/exchangeapi/erResolveNames.js
+++ b/addressbook/exchangeapi/erResolveNames.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/exchangeapi/erSyncContactsFolder.js
+++ b/addressbook/exchangeapi/erSyncContactsFolder.js
@@ -26,12 +26,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erSyncContactsFolderRequest"];
 

--- a/addressbook/exchangeapi/erSyncContactsFolder.js
+++ b/addressbook/exchangeapi/erSyncContactsFolder.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/exchangeapi/exchangeAbFunctions.js
+++ b/addressbook/exchangeapi/exchangeAbFunctions.js
@@ -26,11 +26,11 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = [];
 

--- a/addressbook/exchangeapi/exchangeAbFunctions.js
+++ b/addressbook/exchangeapi/exchangeAbFunctions.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/interface/exchangeAbCard/mivExchangeAbCard.js
+++ b/addressbook/interface/exchangeAbCard/mivExchangeAbCard.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeAbCard() {
 

--- a/addressbook/interface/exchangeAbCard/mivExchangeAbCard.js
+++ b/addressbook/interface/exchangeAbCard/mivExchangeAbCard.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
+++ b/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
@@ -21,7 +21,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
+++ b/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
@@ -20,26 +20,24 @@
  *
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 var Cr = Components.results;
-var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/mailServices.js");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
 
 
 function exchangeAbDirFactory() {}
 
 exchangeAbDirFactory.prototype = {
 
-    classID: components.ID("{e6f8074c-0236-4f51-b8e2-9c528727b4ee}"),
+    classID: Components.ID("{e6f8074c-0236-4f51-b8e2-9c528727b4ee}"),
     contractID: "@mozilla.org/addressbook/directory-factory;1?name=exchWebService-contactRoot-directory",
     classDescription: "Exchange 2007/2010 Contacts DirFactory",
 

--- a/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.manifest
+++ b/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.manifest
@@ -2,5 +2,3 @@ interfaces exchangeAbDirFactory.xpt
 
 component {e6f8074c-0236-4f51-b8e2-9c528727b4ee} exchangeAbDirFactory.js
 contract @mozilla.org/addressbook/directory-factory;1?name=exchWebService-contactRoot-directory {e6f8074c-0236-4f51-b8e2-9c528727b4ee}
-
-

--- a/addressbook/interface/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
+++ b/addressbook/interface/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
@@ -26,22 +26,22 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource:///modules/mailServices.js");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+ChromeUtils.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
 
-Cu.import("resource://exchangeaddress/erFindContacts.js");
-Cu.import("resource://exchangeaddress/erGetContacts.js");
-Cu.import("resource://exchangeaddress/erSyncContactsFolder.js");
-Cu.import("resource://exchangeaddress/erExpandDL.js");
-Cu.import("resource://exchangeaddress/erResolveNames.js");
+ChromeUtils.import("resource://exchangeaddress/erFindContacts.js");
+ChromeUtils.import("resource://exchangeaddress/erGetContacts.js");
+ChromeUtils.import("resource://exchangeaddress/erSyncContactsFolder.js");
+ChromeUtils.import("resource://exchangeaddress/erExpandDL.js");
+ChromeUtils.import("resource://exchangeaddress/erResolveNames.js");
 
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
 
 const nsIAP = Ci.nsIActivityProcess;
 const nsIAE = Ci.nsIActivityEvent;

--- a/addressbook/interface/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
+++ b/addressbook/interface/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/interface/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
+++ b/addressbook/interface/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/interface/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
+++ b/addressbook/interface/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
@@ -26,24 +26,24 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource:///modules/mailServices.js");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+ChromeUtils.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
 
-Cu.import("resource://exchangeaddress/erFindContacts.js");
-Cu.import("resource://exchangeaddress/erGetContacts.js");
-Cu.import("resource://exchangeaddress/erSyncContactsFolder.js");
-Cu.import("resource://exchangeaddress/erExpandDL.js");
-Cu.import("resource://exchangeaddress/erResolveNames.js");
+ChromeUtils.import("resource://exchangeaddress/erFindContacts.js");
+ChromeUtils.import("resource://exchangeaddress/erGetContacts.js");
+ChromeUtils.import("resource://exchangeaddress/erSyncContactsFolder.js");
+ChromeUtils.import("resource://exchangeaddress/erExpandDL.js");
+ChromeUtils.import("resource://exchangeaddress/erResolveNames.js");
 
-//Cu.import("resource://exchangeaddress/exchangeAbDistListDirectory.js");
+//ChromeUtils.import("resource://exchangeaddress/exchangeAbDistListDirectory.js");
 
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
 
 const nsIAP = Ci.nsIActivityProcess;
 const nsIAE = Ci.nsIActivityEvent;

--- a/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
+++ b/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
@@ -20,22 +20,21 @@
  *
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cc = Components.classes;
+
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 var Cr = Components.results;
-var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource:///modules/mailServices.js");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+ChromeUtils.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm");
 
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
 
 //
 // exchangeAbRootDirectory
@@ -83,7 +82,7 @@ function exchangeAbRootDirectory() {
 
 exchangeAbRootDirectory.prototype = {
 
-    classID: components.ID("{227664eb-cce6-4b7a-8d57-0bb0c6c9b362}"),
+    classID: Components.ID("{227664eb-cce6-4b7a-8d57-0bb0c6c9b362}"),
     contractID: "@mozilla.org/addressbook/directory;1?type=exchWebService-contactRoot-directory",
     classDescription: "Exchange 2007/2010 Contacts Root Directory",
 

--- a/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
+++ b/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/addressbook/interface/exchangeAutoCompleteResult/mivExchangeAutoCompleteResult.js
+++ b/addressbook/interface/exchangeAutoCompleteResult/mivExchangeAutoCompleteResult.js
@@ -24,10 +24,10 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/mailServices.js");
 
 function mivExchangeAutoCompleteResult() {
 

--- a/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
+++ b/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
+++ b/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
@@ -24,12 +24,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/mailServices.js");
 
-Cu.import("resource://exchangeaddress/exchangeAbFunctions.js");
+ChromeUtils.import("resource://exchangeaddress/exchangeAbFunctions.js");
 
 function mivExchangeAutoCompleteSearch() {
 

--- a/calendar/content/calendar-calendars-list.js
+++ b/calendar/content/calendar-calendars-list.js
@@ -35,7 +35,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/content/calendar-common-sets.js
+++ b/calendar/content/calendar-common-sets.js
@@ -35,7 +35,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/calendar/content/calendar-common-sets.js
+++ b/calendar/content/calendar-common-sets.js
@@ -37,12 +37,12 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-//Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/erForewardItem.js");
+//ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/erForewardItem.js");
 
 
 //if (! exchWebService) var exchWebService = {};

--- a/calendar/content/calendar-event-dialog-reminder.js
+++ b/calendar/content/calendar-event-dialog-reminder.js
@@ -31,8 +31,8 @@ var Cu = Components.utils;
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://gre/modules/Preferences.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Preferences.jsm");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/calendar/content/calendar-event-dialog-reminder.js
+++ b/calendar/content/calendar-event-dialog-reminder.js
@@ -27,7 +27,7 @@
  * the Initial Developer. All Rights Reserved.
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/calendar/content/calendar-event-dialog.js
+++ b/calendar/content/calendar-event-dialog.js
@@ -2,7 +2,7 @@ var Cu = Components.utils;
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 function exchCalendarEventDialog(aDocument, aWindow) {
     this._document = aDocument;

--- a/calendar/content/calendar-event-dialog.js
+++ b/calendar/content/calendar-event-dialog.js
@@ -1,4 +1,4 @@
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/calendar/content/calendar-properties-dialog.js
+++ b/calendar/content/calendar-properties-dialog.js
@@ -27,7 +27,7 @@
  * the Initial Developer. All Rights Reserved.
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/calendar/content/calendar-summary-dialog.js
+++ b/calendar/content/calendar-summary-dialog.js
@@ -37,12 +37,12 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/erForewardItem.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/erForewardItem.js");
 
 
 //if (! exchWebService) var exchWebService = {};

--- a/calendar/content/calendar-summary-dialog.js
+++ b/calendar/content/calendar-summary-dialog.js
@@ -35,7 +35,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/calendar/content/calendar-task-view.js
+++ b/calendar/content/calendar-task-view.js
@@ -7,8 +7,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
 const globalFunctions = Cc["@1st-setup.nl/global/functions;1"]
     .getService(Ci.mivFunctions);

--- a/calendar/content/calendar-task-view.js
+++ b/calendar/content/calendar-task-view.js
@@ -3,7 +3,7 @@
  */
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/content/delegateCalendar.js
+++ b/calendar/content/delegateCalendar.js
@@ -9,20 +9,20 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/erFindFolder.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/erFindFolder.js");
 
-Cu.import("resource://exchangecalendar/erGetDelegateRequest.js");
-Cu.import("resource://exchangecalendar/erAddDelegateRequest.js");
-Cu.import("resource://exchangecalendar/erRemoveDelegateRequest.js");
-Cu.import("resource://exchangecalendar/erUpdateDelegateRequest.js");
+ChromeUtils.import("resource://exchangecalendar/erGetDelegateRequest.js");
+ChromeUtils.import("resource://exchangecalendar/erAddDelegateRequest.js");
+ChromeUtils.import("resource://exchangecalendar/erRemoveDelegateRequest.js");
+ChromeUtils.import("resource://exchangecalendar/erUpdateDelegateRequest.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 function exchDelegateCalendarSettings(aDocument, aWindow) {
     this._document = aDocument;

--- a/calendar/content/delegateCalendar.js
+++ b/calendar/content/delegateCalendar.js
@@ -7,7 +7,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/calendar/content/ecCalendarCreation.js
+++ b/calendar/content/ecCalendarCreation.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 function exchCalendarCreation(aDocument, aWindow) {
     this._document = aDocument;

--- a/calendar/content/lightning-item-iframe.js
+++ b/calendar/content/lightning-item-iframe.js
@@ -27,7 +27,7 @@
  * the Initial Developer. All Rights Reserved.
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/calendar/content/lightning-item-iframe.js
+++ b/calendar/content/lightning-item-iframe.js
@@ -31,8 +31,8 @@ var Cu = Components.utils;
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function exchangeEventDialog(aDocument, aWindow) {
     this._document = aDocument;

--- a/calendar/content/messenger_task_delegation.js
+++ b/calendar/content/messenger_task_delegation.js
@@ -31,8 +31,8 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-//Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://calendar/modules/calUtils.jsm");
+//ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
 //if (! exchWebService) var exchWebService = {};
 

--- a/calendar/content/messenger_task_delegation.js
+++ b/calendar/content/messenger_task_delegation.js
@@ -29,7 +29,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 //ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 ChromeUtils.import("resource://calendar/modules/calUtils.jsm");

--- a/calendar/exchangeapi/erAddDelegateRequest.js
+++ b/calendar/exchangeapi/erAddDelegateRequest.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erAddDelegateRequest.js
+++ b/calendar/exchangeapi/erAddDelegateRequest.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erAddDelegateRequest"];
 

--- a/calendar/exchangeapi/erCreateAttachment.js
+++ b/calendar/exchangeapi/erCreateAttachment.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/exchangeapi/erCreateAttachment.js
+++ b/calendar/exchangeapi/erCreateAttachment.js
@@ -40,14 +40,14 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erCreateAttachmentRequest"];
 

--- a/calendar/exchangeapi/erDeleteAttachment.js
+++ b/calendar/exchangeapi/erDeleteAttachment.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erDeleteAttachment.js
+++ b/calendar/exchangeapi/erDeleteAttachment.js
@@ -38,14 +38,14 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erDeleteAttachmentRequest"];
 

--- a/calendar/exchangeapi/erFindCalendarItems.js
+++ b/calendar/exchangeapi/erFindCalendarItems.js
@@ -33,7 +33,7 @@
  * the Initial Developer. All Rights Reserved.
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erFindCalendarItems.js
+++ b/calendar/exchangeapi/erFindCalendarItems.js
@@ -35,16 +35,16 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erFindCalendarItemsRequest"];
 

--- a/calendar/exchangeapi/erFindFollowupItems.js
+++ b/calendar/exchangeapi/erFindFollowupItems.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindFollowupItemsRequest"];
 

--- a/calendar/exchangeapi/erFindFollowupItems.js
+++ b/calendar/exchangeapi/erFindFollowupItems.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erFindMasterOccurrences.js
+++ b/calendar/exchangeapi/erFindMasterOccurrences.js
@@ -38,7 +38,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/exchangeapi/erFindMasterOccurrences.js
+++ b/calendar/exchangeapi/erFindMasterOccurrences.js
@@ -42,14 +42,14 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindMasterOccurrencesRequest"];
 

--- a/calendar/exchangeapi/erFindOccurrences.js
+++ b/calendar/exchangeapi/erFindOccurrences.js
@@ -36,18 +36,18 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
+ChromeUtils.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erFindOccurrencesRequest"];
 

--- a/calendar/exchangeapi/erFindOccurrences.js
+++ b/calendar/exchangeapi/erFindOccurrences.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erFindTaskItems.js
+++ b/calendar/exchangeapi/erFindTaskItems.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindTaskItemsRequest"];
 

--- a/calendar/exchangeapi/erFindTaskItems.js
+++ b/calendar/exchangeapi/erFindTaskItems.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erGetDelegateRequest.js
+++ b/calendar/exchangeapi/erGetDelegateRequest.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erGetDelegateRequest.js
+++ b/calendar/exchangeapi/erGetDelegateRequest.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erGetDelegateRequest"];
 

--- a/calendar/exchangeapi/erGetMasterOccurrenceId.js
+++ b/calendar/exchangeapi/erGetMasterOccurrenceId.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetMasterOccurrenceIdRequest"];
 

--- a/calendar/exchangeapi/erGetMasterOccurrenceId.js
+++ b/calendar/exchangeapi/erGetMasterOccurrenceId.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erGetMeetingRequestByUID.js
+++ b/calendar/exchangeapi/erGetMeetingRequestByUID.js
@@ -36,15 +36,15 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 const MAPI_PidLidTaskAccepted = "33032";
 const MAPI_PidLidTaskLastUpdate = "33045";

--- a/calendar/exchangeapi/erGetMeetingRequestByUID.js
+++ b/calendar/exchangeapi/erGetMeetingRequestByUID.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erGetOccurrenceIndex.js
+++ b/calendar/exchangeapi/erGetOccurrenceIndex.js
@@ -36,16 +36,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
+ChromeUtils.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
 
 var EXPORTED_SYMBOLS = ["erGetOccurrenceIndexRequest"];
 

--- a/calendar/exchangeapi/erGetOccurrenceIndex.js
+++ b/calendar/exchangeapi/erGetOccurrenceIndex.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erGetTimeZones.js
+++ b/calendar/exchangeapi/erGetTimeZones.js
@@ -40,15 +40,15 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erGetTimeZonesRequest"];
 

--- a/calendar/exchangeapi/erGetTimeZones.js
+++ b/calendar/exchangeapi/erGetTimeZones.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/exchangeapi/erRemoveDelegateRequest.js
+++ b/calendar/exchangeapi/erRemoveDelegateRequest.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erRemoveDelegateRequest.js
+++ b/calendar/exchangeapi/erRemoveDelegateRequest.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erRemoveDelegateRequest"];
 

--- a/calendar/exchangeapi/erSendMeetingRespons.js
+++ b/calendar/exchangeapi/erSendMeetingRespons.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/calendar/exchangeapi/erSendMeetingRespons.js
+++ b/calendar/exchangeapi/erSendMeetingRespons.js
@@ -38,14 +38,14 @@ var Cu = Components.utils;
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erSendMeetingResponsRequest"];
 

--- a/calendar/exchangeapi/erSyncInbox.js
+++ b/calendar/exchangeapi/erSyncInbox.js
@@ -36,16 +36,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erSyncInboxRequest"];
 

--- a/calendar/exchangeapi/erSyncInbox.js
+++ b/calendar/exchangeapi/erSyncInbox.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erUpdateDelegateRequest.js
+++ b/calendar/exchangeapi/erUpdateDelegateRequest.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/calendar/exchangeapi/erUpdateDelegateRequest.js
+++ b/calendar/exchangeapi/erUpdateDelegateRequest.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erUpdateDelegateRequest"];
 

--- a/calendar/interface/exchangeAttendee/mivExchangeAttendee.js
+++ b/calendar/interface/exchangeAttendee/mivExchangeAttendee.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeAttendee/mivExchangeAttendee.js
+++ b/calendar/interface/exchangeAttendee/mivExchangeAttendee.js
@@ -24,10 +24,10 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 const participationMap = {
     "Unknown": "NEEDS-ACTION",

--- a/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
+++ b/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
@@ -38,7 +38,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
+++ b/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
@@ -42,46 +42,46 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://exchangecommon/erFindFolder.js");
-Cu.import("resource://exchangecommon/erGetFolder.js");
+ChromeUtils.import("resource://exchangecommon/erFindFolder.js");
+ChromeUtils.import("resource://exchangecommon/erGetFolder.js");
 
-Cu.import("resource://exchangecommon/erGetItems.js");
-Cu.import("resource://exchangecommon/erCreateItem.js");
-Cu.import("resource://exchangecommon/erUpdateItem.js");
-Cu.import("resource://exchangecommon/erDeleteItem.js");
+ChromeUtils.import("resource://exchangecommon/erGetItems.js");
+ChromeUtils.import("resource://exchangecommon/erCreateItem.js");
+ChromeUtils.import("resource://exchangecommon/erUpdateItem.js");
+ChromeUtils.import("resource://exchangecommon/erDeleteItem.js");
 
-Cu.import("resource://exchangecommon/erSyncFolderItems.js");
-Cu.import("resource://exchangecommon/erGetUserAvailability.js");
+ChromeUtils.import("resource://exchangecommon/erSyncFolderItems.js");
+ChromeUtils.import("resource://exchangecommon/erGetUserAvailability.js");
 
-Cu.import("resource://exchangecalendar/erFindCalendarItems.js");
-Cu.import("resource://exchangecalendar/erFindTaskItems.js");
-Cu.import("resource://exchangecalendar/erFindFollowupItems.js");
+ChromeUtils.import("resource://exchangecalendar/erFindCalendarItems.js");
+ChromeUtils.import("resource://exchangecalendar/erFindTaskItems.js");
+ChromeUtils.import("resource://exchangecalendar/erFindFollowupItems.js");
 
-Cu.import("resource://exchangecalendar/erFindMasterOccurrences.js");
-Cu.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
-Cu.import("resource://exchangecalendar/erGetMeetingRequestByUID.js");
-Cu.import("resource://exchangecalendar/erFindOccurrences.js");
-Cu.import("resource://exchangecalendar/erGetOccurrenceIndex.js");
+ChromeUtils.import("resource://exchangecalendar/erFindMasterOccurrences.js");
+ChromeUtils.import("resource://exchangecalendar/erGetMasterOccurrenceId.js");
+ChromeUtils.import("resource://exchangecalendar/erGetMeetingRequestByUID.js");
+ChromeUtils.import("resource://exchangecalendar/erFindOccurrences.js");
+ChromeUtils.import("resource://exchangecalendar/erGetOccurrenceIndex.js");
 
-Cu.import("resource://exchangecalendar/erSendMeetingRespons.js");
-Cu.import("resource://exchangecalendar/erSyncInbox.js");
+ChromeUtils.import("resource://exchangecalendar/erSendMeetingRespons.js");
+ChromeUtils.import("resource://exchangecalendar/erSyncInbox.js");
 
-Cu.import("resource://exchangecalendar/erCreateAttachment.js");
-Cu.import("resource://exchangecalendar/erDeleteAttachment.js");
+ChromeUtils.import("resource://exchangecalendar/erCreateAttachment.js");
+ChromeUtils.import("resource://exchangecalendar/erDeleteAttachment.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
-Cu.import("resource://interfacescalendartask/exchangeTodo/mivExchangeTodo.js");
-Cu.import("resource://interfacescalendartask/exchangeEvent/mivExchangeEvent.js");
+ChromeUtils.import("resource://interfacescalendartask/exchangeTodo/mivExchangeTodo.js");
+ChromeUtils.import("resource://interfacescalendartask/exchangeEvent/mivExchangeEvent.js");
 
 var globalStart = new Date().getTime();
 
@@ -9081,7 +9081,7 @@ calExchangeCalendar.prototype = {
 
         try {
             this.logInfo("checkExchCalAddonVerion: ");
-            Cu.import("resource://gre/modules/AddonManager.jsm");
+            ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
             var self = this;
             AddonManager.getAddonByID("exchangecalendar@extensions.1st-setup.nl", function (Addon) {
                 self.removeExchCalDbCache(self, Addon);
@@ -11000,7 +11000,7 @@ exchWebService.check4addon = {
 
         this.alreadyLogged = true;
 
-        Cu.import("resource://gre/modules/AddonManager.jsm");
+        ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
         AddonManager.getAddonByID("exchangecalendar@extensions.1st-setup.nl", exchWebService.check4addon.checkAddOnIsInstalledCallback);
     }
 };

--- a/calendar/interface/exchangeEvent/mivExchangeEvent.js
+++ b/calendar/interface/exchangeEvent/mivExchangeEvent.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeEvent/mivExchangeEvent.js
+++ b/calendar/interface/exchangeEvent/mivExchangeEvent.js
@@ -24,15 +24,15 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommoninterfaces/exchangeBaseItem/mivExchangeBaseItem.js");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/exchangeBaseItem/mivExchangeBaseItem.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 
 var EXPORTED_SYMBOLS = ["mivExchangeEvent"];

--- a/calendar/interface/exchangeRecurrenceInfo/mivExchangeRecurrenceInfo.js
+++ b/calendar/interface/exchangeRecurrenceInfo/mivExchangeRecurrenceInfo.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeRecurrenceInfo() {
 

--- a/calendar/interface/exchangeRecurrenceInfo/mivExchangeRecurrenceInfo.js
+++ b/calendar/interface/exchangeRecurrenceInfo/mivExchangeRecurrenceInfo.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeTimeZones/mivExchangeTimeZone.js
+++ b/calendar/interface/exchangeTimeZones/mivExchangeTimeZone.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeTimeZones/mivExchangeTimeZone.js
+++ b/calendar/interface/exchangeTimeZones/mivExchangeTimeZone.js
@@ -24,12 +24,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 function mivExchangeTimeZone() {
     this._timeZone = null;

--- a/calendar/interface/exchangeTimeZones/mivExchangeTimeZones.js
+++ b/calendar/interface/exchangeTimeZones/mivExchangeTimeZones.js
@@ -24,16 +24,16 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecalendar/erGetTimeZones.js");
+ChromeUtils.import("resource://exchangecalendar/erGetTimeZones.js");
 
-//Cu.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
+//ChromeUtils.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 Cu.importGlobalProperties(["XMLHttpRequest"]);
 
 function mivExchangeTimeZones() {

--- a/calendar/interface/exchangeTodo/mivExchangeTodo.js
+++ b/calendar/interface/exchangeTodo/mivExchangeTodo.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/calendar/interface/exchangeTodo/mivExchangeTodo.js
+++ b/calendar/interface/exchangeTodo/mivExchangeTodo.js
@@ -24,16 +24,16 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommoninterfaces/exchangeBaseItem/mivExchangeBaseItem.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/exchangeBaseItem/mivExchangeBaseItem.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var exchGlobalFunctions = Cc["@1st-setup.nl/global/functions;1"]
     .getService(Ci.mivFunctions);

--- a/common/content/OutOfOfficeMenu.js
+++ b/common/content/OutOfOfficeMenu.js
@@ -38,7 +38,7 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 //if (! exchWebService) var exchWebService = {};
 

--- a/common/content/OutOfOfficeMenu.js
+++ b/common/content/OutOfOfficeMenu.js
@@ -34,7 +34,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/content/addressingWidgetOverlay.js
+++ b/common/content/addressingWidgetOverlay.js
@@ -18,7 +18,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 function exchAddressingWidgetOverlay(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/adutils.js
+++ b/common/content/adutils.js
@@ -19,7 +19,7 @@ var managersignum;
 var searchemail;
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var calWinId = window.arguments[0].calendar.id;
 
 var calPreferences = Cc["@mozilla.org/preferences-service;1"]

--- a/common/content/attachments-view.js
+++ b/common/content/attachments-view.js
@@ -27,7 +27,7 @@
  * the Initial Developer. All Rights Reserved.
  *
  * ***** BEGIN LICENSE BLOCK *****/
-var Cu = Components.utils;
+
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 

--- a/common/content/attachments-view.js
+++ b/common/content/attachments-view.js
@@ -31,8 +31,8 @@ var Cu = Components.utils;
 var Ci = Components.interfaces;
 var Cc = Components.classes;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://exchangecommon/erGetAttachments.js");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://exchangecommon/erGetAttachments.js");
 
 function exchAttachments(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/browseFolder.js
+++ b/common/content/browseFolder.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/content/browseFolder.js
+++ b/common/content/browseFolder.js
@@ -40,11 +40,11 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/erBrowseFolder.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/erBrowseFolder.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/check4lightning.js
+++ b/common/content/check4lightning.js
@@ -29,7 +29,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource:///modules/mailServices.js");
 

--- a/common/content/check4lightning.js
+++ b/common/content/check4lightning.js
@@ -31,7 +31,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource:///modules/mailServices.js");
 
 function exchCheck4Lightning(aDocument, aWindow) {
     this._document = aDocument;
@@ -156,7 +156,7 @@ exchCheck4Lightning.prototype = {
         this.checkingIfLightnigIsInstalled = true;
 
         if (this.lightningIsInstalled == -1) {
-            Cu.import("resource://gre/modules/AddonManager.jsm");
+            ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
         }
         var self = this;
         AddonManager.getAddonByID("{e2fda1a4-762b-4020-b5ad-a41df1933103}", function (aAddon) {

--- a/common/content/debugPreferences.js
+++ b/common/content/debugPreferences.js
@@ -38,7 +38,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/debugPreferences.js
+++ b/common/content/debugPreferences.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/delegateFolder.js
+++ b/common/content/delegateFolder.js
@@ -9,18 +9,18 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://exchangecommon/erUpdateFolderPermission.js");
-Cu.import("resource://exchangecommon/erFindInboxFolder.js");
-Cu.import("resource://exchangecommon/erGetFolderPermission.js");
+ChromeUtils.import("resource://exchangecommon/erUpdateFolderPermission.js");
+ChromeUtils.import("resource://exchangecommon/erFindInboxFolder.js");
+ChromeUtils.import("resource://exchangecommon/erGetFolderPermission.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 function exchDelegateCalendarSettings(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/delegateFolder.js
+++ b/common/content/delegateFolder.js
@@ -7,7 +7,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/common/content/exchangeCloneSettings.js
+++ b/common/content/exchangeCloneSettings.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 function exchExchangeCloneSettings(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/exchangeSettings.js
+++ b/common/content/exchangeSettings.js
@@ -38,7 +38,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
 function exchWebService_permissionsPropertiesView(aProperties) {
 

--- a/common/content/exchangeSettings.js
+++ b/common/content/exchangeSettings.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 

--- a/common/content/exchangeSettingsOverlay.js
+++ b/common/content/exchangeSettingsOverlay.js
@@ -37,18 +37,18 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/erAutoDiscover.js");
-Cu.import("resource://exchangecommon/erAutoDiscoverySOAP.js");
-Cu.import("resource://exchangecommon/erPrimarySMTPCheck.js");
-Cu.import("resource://exchangecommon/erConvertID.js");
-Cu.import("resource://exchangecommon/erFindFolder.js");
-Cu.import("resource://exchangecommon/erGetFolder.js");
-Cu.import("resource://exchangecommon/erGetUserAvailability.js");
+ChromeUtils.import("resource://exchangecommon/erAutoDiscover.js");
+ChromeUtils.import("resource://exchangecommon/erAutoDiscoverySOAP.js");
+ChromeUtils.import("resource://exchangecommon/erPrimarySMTPCheck.js");
+ChromeUtils.import("resource://exchangecommon/erConvertID.js");
+ChromeUtils.import("resource://exchangecommon/erFindFolder.js");
+ChromeUtils.import("resource://exchangecommon/erGetFolder.js");
+ChromeUtils.import("resource://exchangecommon/erGetUserAvailability.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
 function exchSettingsOverlay(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/exchangeSettingsOverlay.js
+++ b/common/content/exchangeSettingsOverlay.js
@@ -35,7 +35,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/content/invitationResponse.js
+++ b/common/content/invitationResponse.js
@@ -38,7 +38,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/invitationResponse.js
+++ b/common/content/invitationResponse.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/lightningtimezoneOverlay.js
+++ b/common/content/lightningtimezoneOverlay.js
@@ -1,6 +1,6 @@
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 
 function lightningTimzone(aDocument, aWindow) {

--- a/common/content/manageEWSAccounts.js
+++ b/common/content/manageEWSAccounts.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 ChromeUtils.import("resource://exchangecommon/erAutoDiscover.js");

--- a/common/content/manageEWSAccounts.js
+++ b/common/content/manageEWSAccounts.js
@@ -24,10 +24,10 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/erAutoDiscover.js");
-Cu.import("resource://exchangecommon/erPrimarySMTPCheck.js");
-Cu.import("resource://exchangecommon/erGetFolder.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/erAutoDiscover.js");
+ChromeUtils.import("resource://exchangecommon/erPrimarySMTPCheck.js");
+ChromeUtils.import("resource://exchangecommon/erGetFolder.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/manageEWSAccountsMenu.js
+++ b/common/content/manageEWSAccountsMenu.js
@@ -22,7 +22,7 @@
  * ***** BEGIN LICENSE BLOCK *****/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/manageEWSAccountsMenu.js
+++ b/common/content/manageEWSAccountsMenu.js
@@ -24,7 +24,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/msgHdrUtils.js
+++ b/common/content/msgHdrUtils.js
@@ -69,9 +69,9 @@ const nsMsgFolderFlags_Drafts = 0x00000400;
 const nsMsgFolderFlags_Archive = 0x00004000;
 const nsMsgFolderFlags_Inbox = 0x00001000;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm"); // for defineLazyServiceGetter
-Cu.import("resource:///modules/iteratorUtils.jsm"); // for toXPCOMArray
-Cu.import("resource:///modules/mailServices.js");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm"); // for defineLazyServiceGetter
+ChromeUtils.import("resource:///modules/iteratorUtils.jsm"); // for toXPCOMArray
+ChromeUtils.import("resource:///modules/mailServices.js");
 
 // Adding a messenger lazy getter to the MailServices even though it's not a service
 XPCOMUtils.defineLazyGetter(MailServices, "messenger", function () {

--- a/common/content/offlineCacheSettings.js
+++ b/common/content/offlineCacheSettings.js
@@ -38,12 +38,12 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/FileUtils.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/FileUtils.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://calendar/modules/calStorageHelpers.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calStorageHelpers.jsm");
 
 function exchOfflineCacheSettings(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/offlineCacheSettings.js
+++ b/common/content/offlineCacheSettings.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/content/oofSettings.js
+++ b/common/content/oofSettings.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 
 ChromeUtils.import("resource://calendar/modules/calUtils.jsm");

--- a/common/content/oofSettings.js
+++ b/common/content/oofSettings.js
@@ -39,16 +39,16 @@ var Ci = Components.interfaces;
 var Cu = Components.utils;
 
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://exchangecommon/erGetUserOofSettings.js");
-Cu.import("resource://exchangecommon/erSetUserOofSettings.js");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://exchangecommon/erGetUserOofSettings.js");
+ChromeUtils.import("resource://exchangecommon/erSetUserOofSettings.js");
 
-//Cu.import("resource://exchangecommon/ecFunctions.js");
+//ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 //if (! exchWebService) var exchWebService = {};
 
 /*if (! this.cal) {
-	Cu.import("resource://calendar/modules/calUtils.jsm", exchWebService);
+	ChromeUtils.import("resource://calendar/modules/calUtils.jsm", exchWebService);
 }
 */
 
@@ -68,7 +68,7 @@ exchOOFSettings.prototype = {
     intOofSettings: {},
 
     onLoad: function _onLoad() {
-        Cu.import("resource://calendar/modules/calUtils.jsm", this);
+        ChromeUtils.import("resource://calendar/modules/calUtils.jsm", this);
         var calId = this._window.arguments[0].calendar.id;
 
         this.calPrefs = Cc["@mozilla.org/preferences-service;1"]

--- a/common/content/otherPreferences.js
+++ b/common/content/otherPreferences.js
@@ -39,7 +39,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 function exchOtherPreferences(aDocument, aWindow) {
     this._document = aDocument;

--- a/common/content/preInvitationResponse.js
+++ b/common/content/preInvitationResponse.js
@@ -38,7 +38,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/preInvitationResponse.js
+++ b/common/content/preInvitationResponse.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/priority-display.js
+++ b/common/content/priority-display.js
@@ -1,6 +1,6 @@
 /* Enhanced priority display */
 
-var Cu = Components.utils;
+
 var Cc = Components.classes;
 var Ci = Components.interfaces;
 Components.utils.import("resource:///modules/iteratorUtils.jsm");

--- a/common/content/progress_panel.js
+++ b/common/content/progress_panel.js
@@ -31,7 +31,7 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-//Cu.import("resource://exchangecommon/ecFunctions.js");
+//ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 //if (! exchWebService) var exchWebService = {};
 

--- a/common/content/progress_panel.js
+++ b/common/content/progress_panel.js
@@ -29,7 +29,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 //ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/selectEWSUrl.js
+++ b/common/content/selectEWSUrl.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 

--- a/common/content/selectEWSUrl.js
+++ b/common/content/selectEWSUrl.js
@@ -36,7 +36,7 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/sendUpdateTo.js
+++ b/common/content/sendUpdateTo.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");

--- a/common/content/sendUpdateTo.js
+++ b/common/content/sendUpdateTo.js
@@ -39,7 +39,7 @@ var Ci = Components.interfaces;
 var Cu = Components.utils;
 
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/sharedCalendarParser.js
+++ b/common/content/sharedCalendarParser.js
@@ -28,8 +28,8 @@ var Ci = Components.interfaces;
 var Cu = Components.utils;
 
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("chrome://exchangecommon/content/msgHdrUtils.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("chrome://exchangecommon/content/msgHdrUtils.js");
 
 if (!exchWebService) var exchWebService = {};
 

--- a/common/content/sharedCalendarParser.js
+++ b/common/content/sharedCalendarParser.js
@@ -25,7 +25,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");

--- a/common/content/timezonePreference.js
+++ b/common/content/timezonePreference.js
@@ -1,6 +1,6 @@
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 var prefs = Cc["@mozilla.org/preferences-service;1"]
     .getService(Ci.nsIPrefService);

--- a/common/exchangeapi/ecExchangeRequest.js
+++ b/common/exchangeapi/ecExchangeRequest.js
@@ -40,15 +40,15 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 Cu.importGlobalProperties(["XMLHttpRequest"]);
 

--- a/common/exchangeapi/ecFunctions.js
+++ b/common/exchangeapi/ecFunctions.js
@@ -23,7 +23,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/exchangeapi/ecFunctions.js
+++ b/common/exchangeapi/ecFunctions.js
@@ -27,8 +27,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var EXPORTED_SYMBOLS = ["exchWebService"];
 

--- a/common/exchangeapi/erAutoDiscover.js
+++ b/common/exchangeapi/erAutoDiscover.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/exchangeapi/erAutoDiscover.js
+++ b/common/exchangeapi/erAutoDiscover.js
@@ -40,12 +40,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
 var EXPORTED_SYMBOLS = ["erAutoDiscoverRequest"];
 

--- a/common/exchangeapi/erAutoDiscoverySOAP.js
+++ b/common/exchangeapi/erAutoDiscoverySOAP.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/exchangeapi/erAutoDiscoverySOAP.js
+++ b/common/exchangeapi/erAutoDiscoverySOAP.js
@@ -40,12 +40,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
 var EXPORTED_SYMBOLS = ["erAutoDiscoverySOAPRequest"];
 

--- a/common/exchangeapi/erBrowseFolder.js
+++ b/common/exchangeapi/erBrowseFolder.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erBrowseFolder.js
+++ b/common/exchangeapi/erBrowseFolder.js
@@ -36,13 +36,13 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erBrowseFolderRequest"];
 

--- a/common/exchangeapi/erConvertID.js
+++ b/common/exchangeapi/erConvertID.js
@@ -36,12 +36,12 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
 var EXPORTED_SYMBOLS = ["erConvertIDRequest"];
 

--- a/common/exchangeapi/erConvertID.js
+++ b/common/exchangeapi/erConvertID.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erCreateItem.js
+++ b/common/exchangeapi/erCreateItem.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erCreateItemRequest"];
 

--- a/common/exchangeapi/erCreateItem.js
+++ b/common/exchangeapi/erCreateItem.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erDeleteItem.js
+++ b/common/exchangeapi/erDeleteItem.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erDeleteItemRequest"];
 

--- a/common/exchangeapi/erDeleteItem.js
+++ b/common/exchangeapi/erDeleteItem.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erFindFolder.js
+++ b/common/exchangeapi/erFindFolder.js
@@ -36,13 +36,13 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindFolderRequest"];
 

--- a/common/exchangeapi/erFindFolder.js
+++ b/common/exchangeapi/erFindFolder.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erFindInboxFolder.js
+++ b/common/exchangeapi/erFindInboxFolder.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erFindInboxFolder.js
+++ b/common/exchangeapi/erFindInboxFolder.js
@@ -9,13 +9,13 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erFindInboxFolderRequest"];
 

--- a/common/exchangeapi/erFindItems.js
+++ b/common/exchangeapi/erFindItems.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erFindItemsRequest"];
 

--- a/common/exchangeapi/erFindItems.js
+++ b/common/exchangeapi/erFindItems.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erForewardItem.js
+++ b/common/exchangeapi/erForewardItem.js
@@ -35,16 +35,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erForewardItemRequest"];
 

--- a/common/exchangeapi/erForewardItem.js
+++ b/common/exchangeapi/erForewardItem.js
@@ -33,7 +33,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erGetAttachments.js
+++ b/common/exchangeapi/erGetAttachments.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");

--- a/common/exchangeapi/erGetAttachments.js
+++ b/common/exchangeapi/erGetAttachments.js
@@ -36,11 +36,11 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erGetAttachmentsRequest"];
 

--- a/common/exchangeapi/erGetEvents.js
+++ b/common/exchangeapi/erGetEvents.js
@@ -10,14 +10,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetEventsRequest"];
 

--- a/common/exchangeapi/erGetEvents.js
+++ b/common/exchangeapi/erGetEvents.js
@@ -8,7 +8,7 @@
  * 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erGetFolder.js
+++ b/common/exchangeapi/erGetFolder.js
@@ -36,18 +36,18 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-/*Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://calendar/modules/calAlarmUtils.jsm");
-Cu.import("resource://calendar/modules/calProviderUtils.jsm");
-Cu.import("resource://calendar/modules/calAuthUtils.jsm");*/
+/*ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calAlarmUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calProviderUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calAuthUtils.jsm");*/
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetFolderRequest"];
 

--- a/common/exchangeapi/erGetFolder.js
+++ b/common/exchangeapi/erGetFolder.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erGetFolderPermission.js
+++ b/common/exchangeapi/erGetFolderPermission.js
@@ -36,18 +36,18 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-/*Cu.import("resource://calendar/modules/calUtils.jsm");
-Cu.import("resource://calendar/modules/calAlarmUtils.jsm");
-Cu.import("resource://calendar/modules/calProviderUtils.jsm");
-Cu.import("resource://calendar/modules/calAuthUtils.jsm");*/
+/*ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calAlarmUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calProviderUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calAuthUtils.jsm");*/
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetFolderPermissionRequest"];
 

--- a/common/exchangeapi/erGetFolderPermission.js
+++ b/common/exchangeapi/erGetFolderPermission.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erGetItems.js
+++ b/common/exchangeapi/erGetItems.js
@@ -38,7 +38,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/exchangeapi/erGetItems.js
+++ b/common/exchangeapi/erGetItems.js
@@ -42,11 +42,11 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erGetItemsRequest"];
 

--- a/common/exchangeapi/erGetUserAvailability.js
+++ b/common/exchangeapi/erGetUserAvailability.js
@@ -36,16 +36,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erGetUserAvailabilityRequest"];
 

--- a/common/exchangeapi/erGetUserAvailability.js
+++ b/common/exchangeapi/erGetUserAvailability.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erGetUserOofSettings.js
+++ b/common/exchangeapi/erGetUserOofSettings.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erGetUserOofSettingsRequest"];
 

--- a/common/exchangeapi/erGetUserOofSettings.js
+++ b/common/exchangeapi/erGetUserOofSettings.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erPrimarySMTPCheck.js
+++ b/common/exchangeapi/erPrimarySMTPCheck.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erPrimarySMTPCheck.js
+++ b/common/exchangeapi/erPrimarySMTPCheck.js
@@ -36,13 +36,13 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
 var EXPORTED_SYMBOLS = ["erPrimarySMTPCheckRequest"];
 

--- a/common/exchangeapi/erSetUserOofSettings.js
+++ b/common/exchangeapi/erSetUserOofSettings.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erSetUserOofSettingsRequest"];
 

--- a/common/exchangeapi/erSetUserOofSettings.js
+++ b/common/exchangeapi/erSetUserOofSettings.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erSubscribe.js
+++ b/common/exchangeapi/erSubscribe.js
@@ -10,13 +10,13 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erSubscribeRequest"];
 

--- a/common/exchangeapi/erSubscribe.js
+++ b/common/exchangeapi/erSubscribe.js
@@ -8,7 +8,7 @@
  * 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erSyncFolderItems.js
+++ b/common/exchangeapi/erSyncFolderItems.js
@@ -38,16 +38,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erSyncFolderItemsRequest"];
 

--- a/common/exchangeapi/erSyncFolderItems.js
+++ b/common/exchangeapi/erSyncFolderItems.js
@@ -36,7 +36,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erUnsubscribe.js
+++ b/common/exchangeapi/erUnsubscribe.js
@@ -10,14 +10,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erUnsubscribeRequest"];
 

--- a/common/exchangeapi/erUnsubscribe.js
+++ b/common/exchangeapi/erUnsubscribe.js
@@ -8,7 +8,7 @@
  * 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erUpdateFolderPermission.js
+++ b/common/exchangeapi/erUpdateFolderPermission.js
@@ -7,7 +7,7 @@
  * http://www.gnu.org/licenses/gpl.html 
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/erUpdateFolderPermission.js
+++ b/common/exchangeapi/erUpdateFolderPermission.js
@@ -9,16 +9,16 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["erUpdateFolderPermissionRequest"];
 

--- a/common/exchangeapi/erUpdateItem.js
+++ b/common/exchangeapi/erUpdateItem.js
@@ -36,14 +36,14 @@
 
 var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-Cu.import("resource://exchangecommon/soapFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/soapFunctions.js");
 
 var EXPORTED_SYMBOLS = ["erUpdateItemRequest"];
 

--- a/common/exchangeapi/erUpdateItem.js
+++ b/common/exchangeapi/erUpdateItem.js
@@ -34,7 +34,7 @@
  *
  * ***** BEGIN LICENSE BLOCK *****/
 
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/Services.jsm");

--- a/common/exchangeapi/soapFunctions.js
+++ b/common/exchangeapi/soapFunctions.js
@@ -40,9 +40,9 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
-//Cu.import("resource://exchangecommon/ecFunctions.js");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
+//ChromeUtils.import("resource://exchangecommon/ecFunctions.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 var EXPORTED_SYMBOLS = ["makeParentFolderIds2", "makeParentFolderIds3", "publicFoldersMap"];
 

--- a/common/exchangeapi/soapFunctions.js
+++ b/common/exchangeapi/soapFunctions.js
@@ -36,7 +36,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeAccountManager/mivExchangeAccountManager.js
+++ b/common/interface/exchangeAccountManager/mivExchangeAccountManager.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeAccountManager() {
 

--- a/common/interface/exchangeAccountManager/mivExchangeAccountManager.js
+++ b/common/interface/exchangeAccountManager/mivExchangeAccountManager.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
+++ b/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
+++ b/common/interface/exchangeAuthPrompt2/mivExchangeAuthPrompt2.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeAuthPrompt2() {
 

--- a/common/interface/exchangeAuthPromptProvider/mivExchangeAuthPromptProvider.js
+++ b/common/interface/exchangeAuthPromptProvider/mivExchangeAuthPromptProvider.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeAuthPromptProvider/mivExchangeAuthPromptProvider.js
+++ b/common/interface/exchangeAuthPromptProvider/mivExchangeAuthPromptProvider.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeAuthPromptProvider() {
     //dump("\nmivExchangeAuthPromptProvider.init\n");

--- a/common/interface/exchangeBadCertListener2/mivExchangeBadCertListener2.js
+++ b/common/interface/exchangeBadCertListener2/mivExchangeBadCertListener2.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeBadCertListener2/mivExchangeBadCertListener2.js
+++ b/common/interface/exchangeBadCertListener2/mivExchangeBadCertListener2.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeBadCertListener2() {
 

--- a/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
+++ b/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
+++ b/common/interface/exchangeBaseItem/mivExchangeBaseItem.js
@@ -24,18 +24,18 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-Cu.import("resource://exchangecommon/ecExchangeRequest.js");
+ChromeUtils.import("resource://exchangecommon/ecExchangeRequest.js");
 
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
-Cu.import("resource://interfacescalendartask/exchangeAttendee/mivExchangeAttendee.js");
+ChromeUtils.import("resource://interfacescalendartask/exchangeAttendee/mivExchangeAttendee.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 const participationMap = {
     "Unknown": "NEEDS-ACTION",

--- a/common/interface/exchangeItemsManager/mivExchangeItemsManager.js
+++ b/common/interface/exchangeItemsManager/mivExchangeItemsManager.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeItemsManager/mivExchangeItemsManager.js
+++ b/common/interface/exchangeItemsManager/mivExchangeItemsManager.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeItemsManager() {
 

--- a/common/interface/exchangeLightningNotifier/mivExchangeLightningNotifier.js
+++ b/common/interface/exchangeLightningNotifier/mivExchangeLightningNotifier.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeLightningNotifier/mivExchangeLightningNotifier.js
+++ b/common/interface/exchangeLightningNotifier/mivExchangeLightningNotifier.js
@@ -24,9 +24,9 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://calendar/modules/calUtils.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://calendar/modules/calUtils.jsm");
 
 function mivExchangeLightningNotifier() {
     this.queue = [];

--- a/common/interface/exchangeLoadBalancer/mivExchangeLoadBalancer.js
+++ b/common/interface/exchangeLoadBalancer/mivExchangeLoadBalancer.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeLoadBalancer/mivExchangeLoadBalancer.js
+++ b/common/interface/exchangeLoadBalancer/mivExchangeLoadBalancer.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function jobObject(aJob, aServer, aLoadBalancer) {
     this.job = aJob;

--- a/common/interface/exchangeStatistics/mivExchangeStatistics.js
+++ b/common/interface/exchangeStatistics/mivExchangeStatistics.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/exchangeStatistics/mivExchangeStatistics.js
+++ b/common/interface/exchangeStatistics/mivExchangeStatistics.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function mivExchangeStatistics() {
     this.serverVersions = {};

--- a/common/interface/global/mivFunctions.js
+++ b/common/interface/global/mivFunctions.js
@@ -27,12 +27,12 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Console.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/Console.jsm");
 
-Cu.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2jxon/mivIxml2jxon.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 
 function mivFunctions() {
     // Mozilla helpers

--- a/common/interface/updater/mivUpdater.js
+++ b/common/interface/updater/mivUpdater.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 Cu.importGlobalProperties(["XMLHttpRequest"]);
 
@@ -209,7 +209,7 @@ mivUpdater.prototype = {
         this._callBack = aCallBack;
         this._extensionID = aExtensionID;
 
-        Cu.import("resource://gre/modules/AddonManager.jsm");
+        ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
         var self = this;
         AddonManager.getAddonByID(aExtensionID, function (aAddon) {
             self.addonByIDCallback(aAddon);

--- a/common/interface/xml2json/xml2json.js
+++ b/common/interface/xml2json/xml2json.js
@@ -1,6 +1,6 @@
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/xml2jxon/mivIxml2jxon.js
+++ b/common/interface/xml2jxon/mivIxml2jxon.js
@@ -26,8 +26,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 function typeString(o) {
     if (typeof o != 'object')

--- a/common/interface/xml2jxon/mivIxml2jxon.js
+++ b/common/interface/xml2jxon/mivIxml2jxon.js
@@ -22,7 +22,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/xml2jxon/mivNameSpaces.js
+++ b/common/interface/xml2jxon/mivNameSpaces.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/xml2jxon/mivNameSpaces.js
+++ b/common/interface/xml2jxon/mivNameSpaces.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 const nsSoapStr = "http://schemas.xmlsoap.org/soap/envelope/";
 const nsTypesStr = "http://schemas.microsoft.com/exchange/services/2006/types";

--- a/common/interface/xml2jxon/mivTagNames.js
+++ b/common/interface/xml2jxon/mivTagNames.js
@@ -20,7 +20,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 var Cr = Components.results;
 var components = Components;
 

--- a/common/interface/xml2jxon/mivTagNames.js
+++ b/common/interface/xml2jxon/mivTagNames.js
@@ -24,8 +24,8 @@ var Cu = Components.utils;
 var Cr = Components.results;
 var components = Components;
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 const nsSoapStr = "http://schemas.xmlsoap.org/soap/envelope/";
 const nsTypesStr = "http://schemas.microsoft.com/exchange/services/2006/types";

--- a/emailtag/content/emailtag.js
+++ b/emailtag/content/emailtag.js
@@ -10,15 +10,15 @@ var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cu = Components.utils;
 
-Cu.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://exchangecommon/erGetItems.js");
-Cu.import("resource://exchangecommon/erFindInboxFolder.js");
-Cu.import("resource://exchangecommon/erSubscribe.js");
-Cu.import("resource://exchangecommon/erGetEvents.js");
-Cu.import("resource://exchangecommon/erFindItems.js");
-Cu.import("resource://exchangecommon/erUpdateItem.js");
-Cu.import("resource://exchangecommon/erUnsubscribe.js");
+ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://exchangecommon/erGetItems.js");
+ChromeUtils.import("resource://exchangecommon/erFindInboxFolder.js");
+ChromeUtils.import("resource://exchangecommon/erSubscribe.js");
+ChromeUtils.import("resource://exchangecommon/erGetEvents.js");
+ChromeUtils.import("resource://exchangecommon/erFindItems.js");
+ChromeUtils.import("resource://exchangecommon/erUpdateItem.js");
+ChromeUtils.import("resource://exchangecommon/erUnsubscribe.js");
 
 const eventTypes = ["NewMailEvent", "ModifiedEvent", "MovedEvent", "CopiedEvent", "CreatedEvent"];
 

--- a/emailtag/content/emailtag.js
+++ b/emailtag/content/emailtag.js
@@ -8,7 +8,7 @@
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
-var Cu = Components.utils;
+
 
 ChromeUtils.import("resource://exchangecommoninterfaces/xml2json/xml2json.js");
 ChromeUtils.import("resource://gre/modules/Services.jsm");


### PR DESCRIPTION
From the Addon 57 manual, I've learned that Components.utils.import() has changed to ChromeUtils.import() and the new one is a bit faster.

In all files that used the `var Cu` only for imports, I've removed it too.