### PR TITLE
exchange-contacts use a new scheme for address books

### DIFF
--- a/addressbook/content/addressbookOverlay.js
+++ b/addressbook/content/addressbookOverlay.js
@@ -73,10 +73,10 @@ exchAddressbookOverlay.prototype = {
             this.prefs.setBoolPref("globalAddressList", input.newAccountObject.addGlobalAddressList);
 
 
-            var theParentDirectory = MailServices.ab.getDirectory("exchWebService-contactRoot-directory://")
+            var theParentDirectory = MailServices.ab.getDirectory("exchangecalendar-addressbook://")
                 .QueryInterface(Ci.nsIAbDirectory);
 
-            var targetURI = "exchWebService-contactRoot-directory://" + newUUID;
+            var targetURI = "exchangecalendar-addressbook://" + newUUID;
             var theChildDirectory = MailServices.ab.getDirectory(targetURI)
                 .QueryInterface(Ci.nsIAbDirectory);
 
@@ -87,7 +87,7 @@ exchAddressbookOverlay.prototype = {
     doDeleteExchangeAccount: function _doDeleteExchangeAccount() {
         exchWebService.commonAbFunctions.logInfo("1. doDeleteExchangeAccount\n");
 
-        var theParentDirectory = MailServices.ab.getDirectory("exchWebService-contactRoot-directory://")
+        var theParentDirectory = MailServices.ab.getDirectory("exchangecalendar-addressbook://")
             .QueryInterface(Ci.nsIAbDirectory);
 
         var theChildDirectory = MailServices.ab.getDirectory(GetSelectedDirectory())
@@ -108,7 +108,7 @@ exchAddressbookOverlay.prototype = {
     onDirTreeSelect: function _onDirTreeSelect() {
         var selectedDir = GetSelectedDirectory();
 
-        if ((selectedDir) && (selectedDir == "exchWebService-contactRoot-directory://")) {
+        if ((selectedDir) && (selectedDir == "exchangecalendar-addressbook://")) {
 
             this._document.getElementById("button-deleteexchangeaccount").hidden = true;
             this._document.getElementById("button-addexchangeaccount").hidden = false;
@@ -167,7 +167,7 @@ exchAddressbookOverlay.prototype = {
     onRightClick: function _onRightClick() {
         var selectedDir = GetSelectedDirectory();
 
-        if ((selectedDir) && (selectedDir == "exchWebService-contactRoot-directory://")) {
+        if ((selectedDir) && (selectedDir == "exchangecalendar-addressbook://")) {
             this._document.getElementById("dirTreeContext-properties").disabled = true;
             this._document.getElementById("dirTreeContext-newcard").hidden = true;
             this._document.getElementById("dirTreeContext-newlist").hidden = true;

--- a/addressbook/content/exchangeContactsInit.js
+++ b/addressbook/content/exchangeContactsInit.js
@@ -33,7 +33,7 @@ function initPreferences() {
         .getBranch("ldap_2.servers.exchangecontacts.");
 
     exchangeContactsInitPrefs.setCharPref("description", "Exchange Contacts");
-    exchangeContactsInitPrefs.setCharPref("uri", "exchWebService-contactRoot-directory://");
+    exchangeContactsInitPrefs.setCharPref("uri", "exchangecalendar-addressbook://");
 
     Cc["@mozilla.org/preferences-service;1"]
         .getService(Ci.nsIPrefService).savePrefFile(null);

--- a/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
+++ b/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.js
@@ -38,7 +38,7 @@ function exchangeAbDirFactory() {}
 exchangeAbDirFactory.prototype = {
 
     classID: Components.ID("{e6f8074c-0236-4f51-b8e2-9c528727b4ee}"),
-    contractID: "@mozilla.org/addressbook/directory-factory;1?name=exchWebService-contactRoot-directory",
+    contractID: "@mozilla.org/addressbook/directory-factory;1?name=exchangecalendar-addressbook",
     classDescription: "Exchange 2007/2010 Contacts DirFactory",
 
     QueryInterface: XPCOMUtils.generateQI([Ci.nsIAbDirFactory]),

--- a/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.manifest
+++ b/addressbook/interface/exchangeAbDirFactory/exchangeAbDirFactory.manifest
@@ -1,4 +1,4 @@
 interfaces exchangeAbDirFactory.xpt
 
 component {e6f8074c-0236-4f51-b8e2-9c528727b4ee} exchangeAbDirFactory.js
-contract @mozilla.org/addressbook/directory-factory;1?name=exchWebService-contactRoot-directory {e6f8074c-0236-4f51-b8e2-9c528727b4ee}
+contract @mozilla.org/addressbook/directory-factory;1?name=exchangecalendar-addressbook {e6f8074c-0236-4f51-b8e2-9c528727b4ee}

--- a/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
+++ b/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.js
@@ -83,7 +83,7 @@ function exchangeAbRootDirectory() {
 exchangeAbRootDirectory.prototype = {
 
     classID: Components.ID("{227664eb-cce6-4b7a-8d57-0bb0c6c9b362}"),
-    contractID: "@mozilla.org/addressbook/directory;1?type=exchWebService-contactRoot-directory",
+    contractID: "@mozilla.org/addressbook/directory;1?type=exchangecalendar-addressbook",
     classDescription: "Exchange 2007/2010 Contacts Root Directory",
 
     // void getInterfaces(out PRUint32 count, [array, size_is(count), retval] out nsIIDPtr array);

--- a/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.manifest
+++ b/addressbook/interface/exchangeAbRootDirectory/exchangeAbRootDirectory.manifest
@@ -1,6 +1,6 @@
 interfaces exchangeAbRootDirectory.xpt
 
 component {227664eb-cce6-4b7a-8d57-0bb0c6c9b362} exchangeAbRootDirectory.js
-contract @mozilla.org/addressbook/directory;1?type=exchWebService-contactRoot-directory {227664eb-cce6-4b7a-8d57-0bb0c6c9b362}
+contract @mozilla.org/addressbook/directory;1?type=exchangecalendar-addressbook {227664eb-cce6-4b7a-8d57-0bb0c6c9b362}
 
 

--- a/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
+++ b/addressbook/interface/exchangeAutoCompleteSearch/mivExchangeAutoCompleteSearch.js
@@ -165,7 +165,7 @@ mivExchangeAutoCompleteSearch.prototype = {
         }
 
         this._searches[uuid].autoCompleteResult.setSearchString(searchString);
-        this._searches[uuid]["rootDir"] = MailServices.ab.getDirectory("exchWebService-contactRoot-directory://?" + query);
+        this._searches[uuid]["rootDir"] = MailServices.ab.getDirectory("exchangecalendar-addressbook://?" + query);
 
         /*		if (this._searches[uuid]["rootDir"]) {
         			var childCards = this._searches[uuid]["rootDir"].childCards;

--- a/common/content/check4lightning.js
+++ b/common/content/check4lightning.js
@@ -167,7 +167,7 @@ exchCheck4Lightning.prototype = {
     onLoad: function _onLoad(event) {
 
         // We preload the exchange Address book
-        var rootDir = MailServices.ab.getDirectory("exchWebService-contactRoot-directory://");
+        var rootDir = MailServices.ab.getDirectory("exchangecalendar-addressbook://");
         var folders = rootDir.childNodes;
 
         this.checkLightningIsInstalled();


### PR DESCRIPTION
To be able to view again the ExchangeContact address book, we have to use lower case in the new scheme created by the extension.

To better show the scheme is specific to the ExchangeCalendar extension, I've updated it to the name `exchangecalendar-addressbook://`.

Fix #209 