### PR TITLE
Fix updates for public calendars

### DIFF
--- a/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
+++ b/calendar/interface/exchangeCalendar/mivExchangeCalendar.js
@@ -8341,6 +8341,8 @@ calExchangeCalendar.prototype = {
                 this.findFollowupTaskItemsOK(erSyncFolderItemsRequest, changes);
                 break;
             default:
+                if (erSyncFolderItemsRequest.folderBase == "publicfoldersroot")
+                    this.findCalendarItemsOK(erSyncFolderItemsRequest, changes, []);
                 this.logError("Changes could not be made." + erSyncFolderItemsRequest.folderBase);
             }
 


### PR DESCRIPTION
This fixes issue #161 

The code in this function assumes that calendars are only in folder called "calendar" but for public calendars the folder is actually "publicfolderroot"

This is a WIP as there might be other folders containing calendars and there are other subfolders in "Public Folder" (our company has a shared addressbook there as well). Since addressbooks are apparently handled somewhere else I just hardcoded that in here. Not a proper solution but works. I would really welcome some suggestions on how to integrate this more properly!