### PR TITLE
fixed missing oof date and time picker

### DIFF
--- a/common/content/oofSettings.xul
+++ b/common/content/oofSettings.xul
@@ -38,6 +38,7 @@
 -->
 <?xml-stylesheet type="text/css" href="chrome://global/skin/"?>
 <?xml-stylesheet type="text/css" href="chrome://global/skin/xul.css"?>
+<?xml-stylesheet type="text/css" href="chrome://messenger/content/bindings.css"?>
 <?xml-stylesheet type="text/css" href="chrome://messenger/skin/messengercompose/messengercompose.css"?>
 <?xml-stylesheet type="text/css" href="chrome://exchangecommon/skin/oofSettings.css"?>
 <?xml-stylesheet type="text/css" href="chrome://exchangecommon/skin/exchWebServiceEditor.css"?>


### PR DESCRIPTION
Since some time the include of chrome://messenger/content/bindings.css is necessary to properly display the date and time pickers.
This fixes the missing date and time pickers in the out of office settings dialog.